### PR TITLE
fix: init Acl

### DIFF
--- a/java/e2e/src/main/java/org/apache/rocketmq/account/Account.java
+++ b/java/e2e/src/main/java/org/apache/rocketmq/account/Account.java
@@ -18,6 +18,7 @@
 package org.apache.rocketmq.account;
 
 public class Account {
+    protected Boolean aclEnable = false;
     /**
      * aliyun AccessKey
      */
@@ -27,65 +28,28 @@ public class Account {
      */
     protected String secretKey;
     /**
-     * instanceUserName
-     */
-    protected String instanceUserName;
-    /**
-     * instancePassword
-     */
-    protected String instancePassword;
-    /**
      * endpoint
      */
     protected String endpoint;
-    /**
-     * instanceId
-     */
-    protected String instanceId;
-    /**
-     * consoleEndpoint
-     */
-    protected String consoleEndpoint;
-    /**
-     * region
-     */
-    protected String regionId;
-    /**
-     * Account User ID
-     */
-    protected String userId;
-    /**
-     * Account User Name
-     */
-    protected String accountName;
-
-    public Account() {
-    }
 
     public Account(String endpoint) {
         this.endpoint = endpoint;
     }
 
-    public Account(String instanceUserName, String instancePassword) {
-        this.instanceUserName = instanceUserName;
-        this.instancePassword = instancePassword;
-    }
 
     public Account(String accessKey, String secretKey, String endpoint) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.endpoint = endpoint;
+        this.aclEnable = true;
     }
 
-    public Account(String accessKey, String secretKey, String endpoint, String instanceId, String consoleEndpoint,
-        String regionId, String userId) {
-        this.accessKey = accessKey;
-        this.secretKey = secretKey;
-        this.endpoint = endpoint;
-        this.instanceId = instanceId;
-        this.consoleEndpoint = consoleEndpoint;
-        this.regionId = regionId;
-        this.userId = userId;
+    public Boolean getAclEnable() {
+        return aclEnable;
+    }
+
+    public void setAclEnable(Boolean aclEnable) {
+        this.aclEnable = aclEnable;
     }
 
     public String getAccessKey() {
@@ -104,67 +68,11 @@ public class Account {
         this.secretKey = secretKey;
     }
 
-    public String getInstanceUserName() {
-        return instanceUserName;
-    }
-
-    public void setInstanceUserName(String instanceUserName) {
-        this.instanceUserName = instanceUserName;
-    }
-
-    public String getInstancePassword() {
-        return instancePassword;
-    }
-
-    public void setInstancePassword(String instancePassword) {
-        this.instancePassword = instancePassword;
-    }
-
     public String getEndpoint() {
         return endpoint;
     }
 
     public void setEndpoint(String endpoint) {
         this.endpoint = endpoint;
-    }
-
-    public String getInstanceId() {
-        return instanceId;
-    }
-
-    public void setInstanceId(String instanceId) {
-        this.instanceId = instanceId;
-    }
-
-    public String getConsoleEndpoint() {
-        return consoleEndpoint;
-    }
-
-    public void setConsoleEndpoint(String consoleEndpoint) {
-        this.consoleEndpoint = consoleEndpoint;
-    }
-
-    public String getRegionId() {
-        return regionId;
-    }
-
-    public void setRegionId(String regionId) {
-        this.regionId = regionId;
-    }
-
-    public String getUserId() {
-        return userId;
-    }
-
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
-
-    public String getAccountName() {
-        return accountName;
-    }
-
-    public void setAccountName(String accountName) {
-        this.accountName = accountName;
     }
 }

--- a/java/e2e/src/main/java/org/apache/rocketmq/factory/ClientConfigurationFactory.java
+++ b/java/e2e/src/main/java/org/apache/rocketmq/factory/ClientConfigurationFactory.java
@@ -20,16 +20,24 @@ package org.apache.rocketmq.factory;
 import java.time.Duration;
 import org.apache.rocketmq.account.Account;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
+import org.apache.rocketmq.client.apis.StaticSessionCredentialsProvider;
 
 public class ClientConfigurationFactory {
-
     public static ClientConfiguration build(Account account) {
-//        StaticSessionCredentialsProvider staticSessionCredentialsProvider = new StaticSessionCredentialsProvider(account.getInstanceUserName(), account.getInstancePassword());
-        ClientConfiguration clientConfiguration = ClientConfiguration.newBuilder()
-            .setEndpoints(account.getEndpoint())
-            .setRequestTimeout(Duration.ofSeconds(10))
-//                .setCredentialProvider(staticSessionCredentialsProvider)
-            .build();
+        ClientConfiguration clientConfiguration;
+        if(account.getAclEnable()) {
+            StaticSessionCredentialsProvider staticSessionCredentialsProvider = new StaticSessionCredentialsProvider(account.getAccessKey(), account.getSecretKey());
+            clientConfiguration = ClientConfiguration.newBuilder()
+                    .setEndpoints(account.getEndpoint())
+                    .setRequestTimeout(Duration.ofSeconds(10))
+                    .setCredentialProvider(staticSessionCredentialsProvider)
+                    .build();
+        }else {
+            clientConfiguration = ClientConfiguration.newBuilder()
+                    .setEndpoints(account.getEndpoint())
+                    .setRequestTimeout(Duration.ofSeconds(10))
+                    .build();
+        }
         return clientConfiguration;
     }
 

--- a/java/e2e/src/main/java/org/apache/rocketmq/frame/ResourceInit.java
+++ b/java/e2e/src/main/java/org/apache/rocketmq/frame/ResourceInit.java
@@ -91,10 +91,10 @@ public class ResourceInit {
     private static void initAcl() {
         aclEnable = Boolean.parseBoolean(System.getProperty("aclEnable", properties.getProperty("aclEnable", "false")));
         if (aclEnable) {
-            String instanceUsername = System.getProperty("INSTANCE_USERNAME", properties.getProperty("INSTANCE_USERNAME"));
-            String instancePassword = System.getProperty("INSTANCE_PASSWORD", properties.getProperty("INSTANCE_PASSWORD"));
-            account = new Account(instanceUsername, instancePassword);
-            log.info("INIT - acl is enabled, [instanceUsername:{}, instancePassword:{}]", instanceUsername, instancePassword);
+            String accessKey = System.getProperty("accessKey", properties.getProperty("accessKey"));
+            String secretKey = System.getProperty("secretKey", properties.getProperty("secretKey"));
+            account = new Account(accessKey, secretKey, endPoint);
+            log.info("INIT - acl is enabled, [accessKey:{}, secretKey:{}]", accessKey, secretKey);
         } else {
             log.info("INIT - acl is disabled");
             account = new Account(endPoint);


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a bug in the test support for ACL, where there was an issue with loading the configuration.

## Brief changelog

This PR adds a fix for the issue with loading the configuration for ACL in the test support.

 * Removed unused fields in Account
 * Added aclEnable field to Account for use in building ClientConfiguration
 * Change `INSTANCE_USERNAME` and `INSTANCE_PASSWORD` to `accessKey` and `secretKey`

