### PR TITLE
Added the java4.x client cluster filter pull test content

### DIFF
--- a/java/e2e-v4/pom.xml
+++ b/java/e2e-v4/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>logback-core</artifactId>
             <version>1.3.0-beta0</version>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/e2e-v4/pom.xml
+++ b/java/e2e-v4/pom.xml
@@ -144,7 +144,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
-                    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                    <argLine>-Xmx1024m</argLine>
                     <rerunFailingTestsCount>1</rerunFailingTestsCount>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalConsumer.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalConsumer.java
@@ -47,8 +47,8 @@ public class RMQNormalConsumer extends AbstractMQConsumer {
     public RMQNormalConsumer(DefaultLitePullConsumer consumer) {
         this.litePullConsumer = consumer;
     }
-    
-    public RMQNormalConsumer(DefaultMQPullConsumer consumer){
+
+    public RMQNormalConsumer(DefaultMQPullConsumer consumer) {
         this.pullConsumer = consumer;
     }
 
@@ -99,7 +99,7 @@ public class RMQNormalConsumer extends AbstractMQConsumer {
         }
         logger.info("DefaultMQLitePullConsumer Assign Mode started");
     }
-    
+
     public void startDefaultPull() {
         Assertions.assertNotNull(pullConsumer);
         try {
@@ -144,7 +144,8 @@ public class RMQNormalConsumer extends AbstractMQConsumer {
         } catch (MQClientException e) {
             logger.info("Start DefaultMQPushConsumer failed, {}", e.getMessage());
         }
-        logger.info("DefaultMQPushConsumer started - topic: {}, messageSelector: {}", topic, messageSelector.getExpression());
+        logger.info("DefaultMQPushConsumer started - topic: {}, messageSelector: {}", topic,
+                messageSelector.getExpression());
         TestUtils.waitForSeconds(5);
     }
 
@@ -154,7 +155,7 @@ public class RMQNormalConsumer extends AbstractMQConsumer {
             pushConsumer.shutdown();
             logger.info("DefaultMQPushConsumer shutdown !!!");
         }
-        if(litePullConsumer != null) {
+        if (litePullConsumer != null) {
             litePullConsumer.shutdown();
             logger.info("DefaultLitePullConsumer shutdown !!!");
         }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalConsumer.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalConsumer.java
@@ -24,6 +24,7 @@ import org.apache.rocketmq.client.consumer.MessageSelector;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.common.AbstractMQConsumer;
 import org.apache.rocketmq.listener.AbstractListener;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQIdempotentListener;
 import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
 import org.apache.rocketmq.listener.rmq.concurrent.RMQOrderListener;
 import org.apache.rocketmq.utils.TestUtils;
@@ -52,6 +53,19 @@ public class RMQNormalConsumer extends AbstractMQConsumer {
     }
 
     public void subscribeAndStart(String topic, String tag, RMQNormalListener listener) {
+        Assertions.assertNotNull(pushConsumer);
+        this.listener = listener;
+        try {
+            pushConsumer.subscribe(topic, tag);
+            pushConsumer.setMessageListener(listener);
+            pushConsumer.start();
+        } catch (MQClientException e) {
+            logger.info("Start DefaultMQPushConsumer failed, {}", e.getMessage());
+        }
+        logger.info("DefaultMQPushConsumer started - topic: {}, tag: {}", topic, tag);
+    }
+
+    public void subscribeAndStart(String topic, String tag, RMQIdempotentListener listener) {
         Assertions.assertNotNull(pushConsumer);
         this.listener = listener;
         try {

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalConsumer.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalConsumer.java
@@ -17,6 +17,8 @@
 
 package org.apache.rocketmq.client.rmq;
 
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 import org.apache.rocketmq.client.consumer.MessageSelector;
 import org.apache.rocketmq.client.exception.MQClientException;
@@ -25,37 +27,93 @@ import org.apache.rocketmq.listener.AbstractListener;
 import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
 import org.apache.rocketmq.listener.rmq.concurrent.RMQOrderListener;
 import org.apache.rocketmq.utils.TestUtils;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RMQNormalConsumer extends AbstractMQConsumer {
     private static Logger logger = LoggerFactory.getLogger(RMQNormalConsumer.class);
 
-    private DefaultMQPushConsumer consumer;
+    private DefaultMQPushConsumer pushConsumer;
+    private DefaultLitePullConsumer litePullConsumer;
+    private DefaultMQPullConsumer pullConsumer;
     private AbstractListener listener = null;
 
     public RMQNormalConsumer(DefaultMQPushConsumer consumer) {
-        this.consumer = consumer;
+        this.pushConsumer = consumer;
+    }
+
+    public RMQNormalConsumer(DefaultLitePullConsumer consumer) {
+        this.litePullConsumer = consumer;
+    }
+    
+    public RMQNormalConsumer(DefaultMQPullConsumer consumer){
+        this.pullConsumer = consumer;
     }
 
     public void subscribeAndStart(String topic, String tag, RMQNormalListener listener) {
+        Assertions.assertNotNull(pushConsumer);
         this.listener = listener;
         try {
-            consumer.subscribe(topic, tag);
-            consumer.setMessageListener(listener);
-            consumer.start();
+            pushConsumer.subscribe(topic, tag);
+            pushConsumer.setMessageListener(listener);
+            pushConsumer.start();
         } catch (MQClientException e) {
             logger.info("Start DefaultMQPushConsumer failed, {}", e.getMessage());
         }
         logger.info("DefaultMQPushConsumer started - topic: {}, tag: {}", topic, tag);
     }
 
+    public void subscribeAndStartLitePull(String topic, String tag) {
+        Assertions.assertNotNull(litePullConsumer);
+        try {
+            litePullConsumer.subscribe(topic, tag);
+            litePullConsumer.start();
+        } catch (MQClientException e) {
+            logger.info("Start DefaultMQLitePullConsumer failed, {}", e.getMessage());
+        }
+        logger.info("DefaultMQLitePullConsumer started - topic: {}, tag: {}", topic, tag);
+    }
+
+    public void startLitePullAssignMode() {
+        Assertions.assertNotNull(litePullConsumer);
+        try {
+            litePullConsumer.setAutoCommit(false);
+            litePullConsumer.start();
+        } catch (MQClientException e) {
+            logger.info("Start DefaultMQLitePullConsumer failed, {}", e.getMessage());
+        }
+        logger.info("DefaultMQLitePullConsumer Assign Mode started");
+    }
+    
+    public void startDefaultPull() {
+        Assertions.assertNotNull(pullConsumer);
+        try {
+            pullConsumer.start();
+        } catch (MQClientException e) {
+            logger.info("Start DefaultMQPullConsumer failed, {}", e.getMessage());
+        }
+        logger.info("DefaultMQPullConsumer started");
+    }
+
+    public void subscribeAndStartLitePull(String topic, MessageSelector messageSelector) {
+        Assertions.assertNotNull(litePullConsumer);
+        try {
+            litePullConsumer.subscribe(topic, messageSelector);
+            litePullConsumer.start();
+        } catch (MQClientException e) {
+            logger.info("Start DefaultMQPushConsumer failed, {}", e.getMessage());
+        }
+        logger.info("DefaultMQLitePullConsumer started - topic: {}, sql: {}", topic, messageSelector.getExpression());
+    }
+
     public void subscribeAndStart(String topic, String tag, RMQOrderListener listener) {
+        Assertions.assertNotNull(pushConsumer);
         this.listener = listener;
         try {
-            consumer.subscribe(topic, tag);
-            consumer.setMessageListener(listener);
-            consumer.start();
+            pushConsumer.subscribe(topic, tag);
+            pushConsumer.setMessageListener(listener);
+            pushConsumer.start();
         } catch (MQClientException e) {
             logger.info("Start DefaultMQPushConsumer failed, {}", e.getMessage());
         }
@@ -63,11 +121,12 @@ public class RMQNormalConsumer extends AbstractMQConsumer {
     }
 
     public void subscribeAndStart(String topic, MessageSelector messageSelector, RMQNormalListener listener) {
+        Assertions.assertNotNull(pushConsumer);
         this.listener = listener;
         try {
-            consumer.subscribe(topic, messageSelector);
-            consumer.setMessageListener(listener);
-            consumer.start();
+            pushConsumer.subscribe(topic, messageSelector);
+            pushConsumer.setMessageListener(listener);
+            pushConsumer.start();
         } catch (MQClientException e) {
             logger.info("Start DefaultMQPushConsumer failed, {}", e.getMessage());
         }
@@ -77,18 +136,22 @@ public class RMQNormalConsumer extends AbstractMQConsumer {
 
     @Override
     public void shutdown() {
-        if (consumer != null) {
-            consumer.shutdown();
+        if (pushConsumer != null) {
+            pushConsumer.shutdown();
             logger.info("DefaultMQPushConsumer shutdown !!!");
+        }
+        if(litePullConsumer != null) {
+            litePullConsumer.shutdown();
+            logger.info("DefaultLitePullConsumer shutdown !!!");
         }
     }
 
-    public DefaultMQPushConsumer getConsumer() {
-        return consumer;
+    public DefaultMQPushConsumer getPushConsumer() {
+        return pushConsumer;
     }
 
-    public void setConsumer(DefaultMQPushConsumer consumer) {
-        this.consumer = consumer;
+    public void setPushConsumer(DefaultMQPushConsumer consumer) {
+        this.pushConsumer = consumer;
     }
 
     public AbstractListener getListener() {
@@ -97,5 +160,21 @@ public class RMQNormalConsumer extends AbstractMQConsumer {
 
     public void setListener(AbstractListener listener) {
         this.listener = listener;
+    }
+
+    public DefaultLitePullConsumer getLitePullConsumer() {
+        return litePullConsumer;
+    }
+
+    public void setLitePullConsumer(DefaultLitePullConsumer consumer) {
+        this.litePullConsumer = consumer;
+    }
+
+    public DefaultMQPullConsumer getPullConsumer() {
+        return pullConsumer;
+    }
+
+    public void setPullConsumer(DefaultMQPullConsumer consumer) {
+        this.pullConsumer = consumer;
     }
 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalProducer.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalProducer.java
@@ -113,7 +113,7 @@ public class RMQNormalProducer extends AbstractMQProducer {
      * @param mqs        Queue列表
      * @param messageNum 每个Queue发送的消息数量
      */
-    public void sendWithQueue(List<MessageQueue> mqs,String tag, int messageNum) {
+    public void sendWithQueue(List<MessageQueue> mqs, String tag, int messageNum) {
         logger.info("Producer start to send messages");
         for (MessageQueue mq : mqs) {
             for (int i = 0; i < messageNum; i++) {
@@ -184,7 +184,7 @@ public class RMQNormalProducer extends AbstractMQProducer {
                 e.printStackTrace();
             }
             logger.info(sendResult.toString());
-            this.enqueueMessages.addData((MessageExt)message);
+            this.enqueueMessages.addData((MessageExt) message);
         }
         Assertions.assertEquals(messageNum, enqueueMessages.getAllData().size(), "消息没有全部发送成功！");
         logger.info("Producer send messages finished");
@@ -221,24 +221,26 @@ public class RMQNormalProducer extends AbstractMQProducer {
     }
 
     //
-    //public void sendAsyncWithTagAndBody(String topic, String tag, String messageBody, OnsSendCallBack callBack, int messageNum) {
-    //    logger.info("Producer start to async send messages");
-    //    for (int i = 0; i < messageNum; i++) {
-    //        Message message = MessageFactory.buildOneMessageWithTagAndBody(topic, tag, messageBody);
-    //        producer.sendAsync(message, callBack);
-    //        callBack.waitResponse();
-    //        if (callBack.isBSuccessResponse()) {
-    //            this.enqueueMessages.addData(message);
-    //        }
-    //        if (callBack.isBFailResponse()) {
-    //            this.enqueueFailedMessages.addData(message);
-    //        }
-    //    }
-    //    logger.info("Producer async send messages finished");
-    //    if (enqueueFailedMessages.getAllData().size() > 0) {
-    //        logger.warn("send failed messages: {}", enqueueFailedMessages.getAllData());
-    //    }
-    //}
+    // public void sendAsyncWithTagAndBody(String topic, String tag, String
+    // messageBody, OnsSendCallBack callBack, int messageNum) {
+    // logger.info("Producer start to async send messages");
+    // for (int i = 0; i < messageNum; i++) {
+    // Message message = MessageFactory.buildOneMessageWithTagAndBody(topic, tag,
+    // messageBody);
+    // producer.sendAsync(message, callBack);
+    // callBack.waitResponse();
+    // if (callBack.isBSuccessResponse()) {
+    // this.enqueueMessages.addData(message);
+    // }
+    // if (callBack.isBFailResponse()) {
+    // this.enqueueFailedMessages.addData(message);
+    // }
+    // }
+    // logger.info("Producer async send messages finished");
+    // if (enqueueFailedMessages.getAllData().size() > 0) {
+    // logger.warn("send failed messages: {}", enqueueFailedMessages.getAllData());
+    // }
+    // }
     //
     public void sendAsync(String topic, String tag, RMQSendCallBack callBack, int messageNum) {
         logger.info("Producer start to async send messages");
@@ -305,7 +307,7 @@ public class RMQNormalProducer extends AbstractMQProducer {
             MessageExt messageExt = null;
             try {
                 producer.sendOneway(message);
-                //this.enqueueMessages.addData(messageExt);
+                // this.enqueueMessages.addData(messageExt);
             } catch (MQClientException e) {
                 e.printStackTrace();
             } catch (RemotingException e) {
@@ -331,8 +333,9 @@ public class RMQNormalProducer extends AbstractMQProducer {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
-            //logger.info("topic: {}, msgId: {}, index: {}, tag: {}, body:{}", topic, message.getMsgID(), i, tag, messageBody);
-            this.enqueueMessages.addData((MessageExt)message);
+            // logger.info("topic: {}, msgId: {}, index: {}, tag: {}, body:{}", topic,
+            // message.getMsgID(), i, tag, messageBody);
+            this.enqueueMessages.addData((MessageExt) message);
         }
         logger.info("Producer send messages finished");
     }
@@ -370,105 +373,118 @@ public class RMQNormalProducer extends AbstractMQProducer {
         logger.info("Producer send delay messages finished");
     }
 
-    ///**
+    /// **
     // * 发送延迟消息
     // *
-    // * @param topic           topic名称
+    // * @param topic topic名称
     // * @param delaySecondTime 延迟时间，单位:秒
-    // * @param messageNum      消息条数
-    // */
-    //public void sendDelayWithTag(String topic, String tag, int delaySecondTime, int messageNum) {
-    //    logger.info("Producer start to send delay messages");
-    //    for (int i = 0; i < messageNum; i++) {
-    //        Message message = MessageFactory.buildOneMessageWithTagAndStartDeliverTime(topic, tag,
-    //            System.currentTimeMillis() + delaySecondTime * 1000L);
-    //        SendResult sendResult = producer.send(message);
-    //        logger.info(sendResult.toString());
-    //        this.enqueueMessages.addData(message);
-    //    }
-    //    logger.info("Producer send delay messages finished");
-    //}
-    //
-    ///**
-    // * 发送定时消息
-    // *
-    // * @param topic      topic名称
-    // * @param time       定时消息的时间戳
     // * @param messageNum 消息条数
     // */
-    //public void sendTimingWithTag(String topic, String tag, long time, int messageNum) {
-    //    logger.info("Producer start to send delay messages");
-    //    for (int i = 0; i < messageNum; i++) {
-    //        String deliverTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(System.currentTimeMillis() + time * 1000L));
-    //        Message message = MessageFactory.buildOneTimingMessageWithTag(topic, tag, UUID.randomUUID().toString(), deliverTime);
-    //        SendResult sendResult = producer.send(message);
-    //        logger.info(sendResult.toString());
-    //        this.enqueueMessages.addData(message);
-    //    }
-    //    logger.info("Producer send delay messages finished");
-    //}
+    // public void sendDelayWithTag(String topic, String tag, int delaySecondTime,
+    /// int messageNum) {
+    // logger.info("Producer start to send delay messages");
+    // for (int i = 0; i < messageNum; i++) {
+    // Message message =
+    /// MessageFactory.buildOneMessageWithTagAndStartDeliverTime(topic, tag,
+    // System.currentTimeMillis() + delaySecondTime * 1000L);
+    // SendResult sendResult = producer.send(message);
+    // logger.info(sendResult.toString());
+    // this.enqueueMessages.addData(message);
+    // }
+    // logger.info("Producer send delay messages finished");
+    // }
     //
-    ///**
+    /// **
     // * 发送定时消息
     // *
-    // * @param topic      topic名称
-    // * @param time       定时消息的时间戳
+    // * @param topic topic名称
+    // * @param time 定时消息的时间戳
     // * @param messageNum 消息条数
     // */
-    //public void sendTimingWithTagAndBody(String topic, String tag, String body, long time, int messageNum) {
-    //    logger.info("Producer start to send delay messages");
-    //    for (int i = 0; i < messageNum; i++) {
-    //        String deliverTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(System.currentTimeMillis() + time * 1000L));
-    //        Message message = MessageFactory.buildOneTimingMessageWithTag(topic, tag, body, deliverTime);
-    //        SendResult sendResult = producer.send(message);
-    //        logger.info(sendResult.toString());
-    //        this.enqueueMessages.addData(message);
-    //    }
-    //    logger.info("Producer send delay messages finished");
-    //}
+    // public void sendTimingWithTag(String topic, String tag, long time, int
+    /// messageNum) {
+    // logger.info("Producer start to send delay messages");
+    // for (int i = 0; i < messageNum; i++) {
+    // String deliverTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new
+    /// Date(System.currentTimeMillis() + time * 1000L));
+    // Message message = MessageFactory.buildOneTimingMessageWithTag(topic, tag,
+    /// UUID.randomUUID().toString(), deliverTime);
+    // SendResult sendResult = producer.send(message);
+    // logger.info(sendResult.toString());
+    // this.enqueueMessages.addData(message);
+    // }
+    // logger.info("Producer send delay messages finished");
+    // }
     //
-    ///**
-    // * @param topic      发送topic
-    // * @param tag        消息tag
+    /// **
+    // * 发送定时消息
+    // *
+    // * @param topic topic名称
+    // * @param time 定时消息的时间戳
+    // * @param messageNum 消息条数
+    // */
+    // public void sendTimingWithTagAndBody(String topic, String tag, String body,
+    /// long time, int messageNum) {
+    // logger.info("Producer start to send delay messages");
+    // for (int i = 0; i < messageNum; i++) {
+    // String deliverTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new
+    /// Date(System.currentTimeMillis() + time * 1000L));
+    // Message message = MessageFactory.buildOneTimingMessageWithTag(topic, tag,
+    /// body, deliverTime);
+    // SendResult sendResult = producer.send(message);
+    // logger.info(sendResult.toString());
+    // this.enqueueMessages.addData(message);
+    // }
+    // logger.info("Producer send delay messages finished");
+    // }
+    //
+    /// **
+    // * @param topic 发送topic
+    // * @param tag 消息tag
     // * @param messageNum 消息数量
-    // * @param userProps  消息属性
+    // * @param userProps 消息属性
     // */
-    //public void sendWithTagAndUserProps(String topic, String tag, int messageNum, HashMap<String, String> userProps) {
-    //    logger.info("Producer start to send messages");
-    //    for (int i = 0; i < messageNum; i++) {
-    //        Message message = MessageFactory.buildOneMessageWithTagAndUserProps(topic, tag, UUID.randomUUID().toString(), userProps);
-    //        SendResult sendResult = producer.send(message);
-    //        logger.info(sendResult.toString());
-    //        this.enqueueMessages.addData(message);
-    //    }
-    //    logger.info("Producer send messages finished");
-    //}
+    // public void sendWithTagAndUserProps(String topic, String tag, int messageNum,
+    /// HashMap<String, String> userProps) {
+    // logger.info("Producer start to send messages");
+    // for (int i = 0; i < messageNum; i++) {
+    // Message message = MessageFactory.buildOneMessageWithTagAndUserProps(topic,
+    /// tag, UUID.randomUUID().toString(), userProps);
+    // SendResult sendResult = producer.send(message);
+    // logger.info(sendResult.toString());
+    // this.enqueueMessages.addData(message);
+    // }
+    // logger.info("Producer send messages finished");
+    // }
     //
-    ///**
-    // * @param topic        发送topic
-    // * @param tag          消息tag
+    /// **
+    // * @param topic 发送topic
+    // * @param tag 消息tag
     // * @param delaySeconds 消息延迟 单位：s
-    // * @param messageNum   消息数量
-    // * @param userProps    消息属性
+    // * @param messageNum 消息数量
+    // * @param userProps 消息属性
     // */
-    //public void sendDelayWithTagAndUserProps(String topic, String tag, int delaySeconds, int messageNum, HashMap<String, String> userProps) {
-    //    logger.info("Producer start to send messages");
-    //    for (int i = 0; i < messageNum; i++) {
-    //        Message message = MessageFactory.buildOneDelayMessageWithTagAndUserProps(topic, tag, System.currentTimeMillis() + delaySeconds * 1000L,
-    //            UUID.randomUUID().toString(), userProps);
-    //        SendResult sendResult = producer.send(message);
-    //        logger.info(sendResult.toString());
-    //        this.enqueueMessages.addData(message);
-    //    }
-    //    logger.info("Producer send messages finished");
-    //}
+    // public void sendDelayWithTagAndUserProps(String topic, String tag, int
+    /// delaySeconds, int messageNum, HashMap<String, String> userProps) {
+    // logger.info("Producer start to send messages");
+    // for (int i = 0; i < messageNum; i++) {
+    // Message message =
+    /// MessageFactory.buildOneDelayMessageWithTagAndUserProps(topic, tag,
+    /// System.currentTimeMillis() + delaySeconds * 1000L,
+    // UUID.randomUUID().toString(), userProps);
+    // SendResult sendResult = producer.send(message);
+    // logger.info(sendResult.toString());
+    // this.enqueueMessages.addData(message);
+    // }
+    // logger.info("Producer send messages finished");
+    // }
 
     public void send(String topic, String tag, String body) {
         logger.info("Producer start to send messages");
 
         Message message = null;
         try {
-            message = MessageFactory.buildMessage(topic, tag,body);
+            message = MessageFactory.buildMessage(topic, tag, body);
         } catch (Exception e) {
             logger.error("build message failed");
         }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalProducer.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQNormalProducer.java
@@ -502,7 +502,6 @@ public class RMQNormalProducer extends AbstractMQProducer {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-        logger.info(sendResult.toString());
         this.enqueueMessages.addData(messageExt);
     }
 

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQTransactionProducer.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQTransactionProducer.java
@@ -38,9 +38,10 @@ public class RMQTransactionProducer extends AbstractMQProducer {
         this.producer = producer;
     }
     //
-    //public RMQTransactionProducer(String nsAddr, String topic, TransactionListener transactionListener) {
-    //    this(nsAddr, topic, false, transactionListener);
-    //}
+    // public RMQTransactionProducer(String nsAddr, String topic,
+    // TransactionListener transactionListener) {
+    // this(nsAddr, topic, false, transactionListener);
+    // }
 
     @Override
     public void shutdown() {
@@ -50,7 +51,8 @@ public class RMQTransactionProducer extends AbstractMQProducer {
     public void send(String topic, String tag, int messageNum) {
         logger.info("Producer start to send messages");
         for (int i = 0; i < messageNum; i++) {
-            //Message message = MessageFactory.buildOneMessageWithTagAndBody(topic, tag, String.valueOf(i));
+            // Message message = MessageFactory.buildOneMessageWithTagAndBody(topic, tag,
+            // String.valueOf(i));
             Message message = MessageFactory.buildOneMessageWithTag(topic, tag);
             SendResult sendResult = null;
             MessageExt messageExt = null;
@@ -72,11 +74,12 @@ public class RMQTransactionProducer extends AbstractMQProducer {
         }
         logger.info("Producer send messages finished");
     }
-    
+
     public void sendTrans(String topic, String tag, int messageNum) {
         logger.info("Producer start to send transaction messages");
         for (int i = 0; i < messageNum; i++) {
-            //Message message = MessageFactory.buildOneMessageWithTagAndBody(topic, tag, String.valueOf(i));
+            // Message message = MessageFactory.buildOneMessageWithTagAndBody(topic, tag,
+            // String.valueOf(i));
             Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
             SendResult sendResult = null;
             MessageExt messageExt = null;

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQTransactionProducer.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/client/rmq/RMQTransactionProducer.java
@@ -72,5 +72,25 @@ public class RMQTransactionProducer extends AbstractMQProducer {
         }
         logger.info("Producer send messages finished");
     }
+    
+    public void sendTrans(String topic, String tag, int messageNum) {
+        logger.info("Producer start to send transaction messages");
+        for (int i = 0; i < messageNum; i++) {
+            //Message message = MessageFactory.buildOneMessageWithTagAndBody(topic, tag, String.valueOf(i));
+            Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
+            SendResult sendResult = null;
+            MessageExt messageExt = null;
+            try {
+                sendResult = producer.sendMessageInTransaction(message, null);
+                messageExt = new MessageExt();
+                messageExt.setMsgId(sendResult.getMsgId());
+                logger.info("{}, index: {}, tag: {}", sendResult, i, tag);
+                this.enqueueMessages.addData(messageExt);
+            } catch (MQClientException e) {
+                e.printStackTrace();
+            }
+        }
+        logger.info("Producer send messages finished");
+    }
 
 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/common/MQCollector.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/common/MQCollector.java
@@ -40,15 +40,17 @@ public abstract class MQCollector {
      * 全部出队的消息体（去重）
      */
     protected DataCollector<String> dequeueUndupMessageBody = null;
-    //消息发送响应时间收集器
+    // 消息发送响应时间收集器
     protected DataCollector msgRTs = null;
 
     public MQCollector() {
         enqueueMessages = DataCollectorManager.getInstance().fetchListDataCollector(RandomUtils.getStringByUUID());
-        enqueueFailedMessages = DataCollectorManager.getInstance().fetchListDataCollector(RandomUtils.getStringByUUID());
+        enqueueFailedMessages = DataCollectorManager.getInstance()
+                .fetchListDataCollector(RandomUtils.getStringByUUID());
         dequeueMessages = DataCollectorManager.getInstance().fetchListDataCollector(RandomUtils.getStringByUUID());
         dequeueAllMessages = DataCollectorManager.getInstance().fetchListDataCollector(RandomUtils.getStringByUUID());
-        dequeueUndupMessageBody = DataCollectorManager.getInstance().fetchListDataCollector(RandomUtils.getStringByUUID());
+        dequeueUndupMessageBody = DataCollectorManager.getInstance()
+                .fetchListDataCollector(RandomUtils.getStringByUUID());
 
         msgRTs = DataCollectorManager.getInstance().fetchListDataCollector(RandomUtils.getStringByUUID());
     }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/enums/TESTSET.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/enums/TESTSET.java
@@ -49,5 +49,5 @@ public class TESTSET {
     public static final String CLUSTER = "cluster";
     public static final String BROADCAST = "broadcast";
     public static final String ACL = "acl";
-    public static final String SIMPLE = "Simple";
+    public static final String MODEL = "model";
 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/enums/TESTSET.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/enums/TESTSET.java
@@ -50,4 +50,7 @@ public class TESTSET {
     public static final String BROADCAST = "broadcast";
     public static final String ACL = "acl";
     public static final String MODEL = "model";
+    public static final String LOAD_BALANCING = "loadBalancing";
+    public static final String BATCHPRODUCER = "batchProducer";
+    public static final String OFFSET = "offset";
 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/enums/TESTSET.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/enums/TESTSET.java
@@ -38,19 +38,34 @@ public class TESTSET {
     public static final String TRANSACTION = "transaction";
 
     public static final String PULL = "pull";
+
     public static final String BATCH_CONSUME = "batchConsume";
+
     public static final String DEADLETTER = "deadletter";
+
     public static final String REBALANCE = "rebalance";
+
     public static final String CLIENT = "client";
+
     public static final String RETRY = "retry";
+
     public static final String ASNYC = "async";
+
     public static final String TAG = "tag";
+
     public static final String SQL = "sql";
+
     public static final String CLUSTER = "cluster";
+
     public static final String BROADCAST = "broadcast";
+
     public static final String ACL = "acl";
+
     public static final String MODEL = "model";
+
     public static final String LOAD_BALANCING = "loadBalancing";
+
     public static final String BATCHPRODUCER = "batchProducer";
+    
     public static final String OFFSET = "offset";
 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/ConsumerFactory.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/ConsumerFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.rocketmq.factory;
 
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
 import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
@@ -43,6 +45,46 @@ public class ConsumerFactory {
         }
         consumer.setInstanceName(RandomUtils.getStringByUUID());
         consumer.setNamesrvAddr(nsAddr);
+        return new RMQNormalConsumer(consumer);
+    }
+
+    public static RMQNormalConsumer getRMQLitePullConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook){
+        DefaultLitePullConsumer consumer;
+        if (aclEnable) {
+            consumer = new DefaultLitePullConsumer(consumerGroup, rpcHook);
+        } else {
+            consumer = new DefaultLitePullConsumer(consumerGroup);
+        }
+        consumer.setNamesrvAddr(nsAddr);
+        consumer.setInstanceName(RandomUtils.getStringByUUID());
+        consumer.setConsumerPullTimeoutMillis(5000);
+        return new RMQNormalConsumer(consumer);
+    }
+
+    public static RMQNormalConsumer getRMQLitePullConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook, int batchSize){
+        DefaultLitePullConsumer consumer;
+        if (aclEnable) {
+            consumer = new DefaultLitePullConsumer(consumerGroup, rpcHook);
+        } else {
+            consumer = new DefaultLitePullConsumer(consumerGroup);
+        }
+        consumer.setNamesrvAddr(nsAddr);
+        consumer.setInstanceName(RandomUtils.getStringByUUID());
+        consumer.setConsumerPullTimeoutMillis(5000);
+        consumer.setPullBatchSize(batchSize);
+        return new RMQNormalConsumer(consumer);
+    }
+
+    public static RMQNormalConsumer getRMQPullConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook){
+        DefaultMQPullConsumer consumer;
+        if (aclEnable) {
+            consumer = new DefaultMQPullConsumer(consumerGroup, rpcHook);
+        } else {
+            consumer = new DefaultMQPullConsumer(consumerGroup);
+        }
+        consumer.setInstanceName(RandomUtils.getStringByUUID());
+        consumer.setNamesrvAddr(nsAddr);
+        consumer.setInstanceName(RandomUtils.getStringByUUID());
         return new RMQNormalConsumer(consumer);
     }
 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/ConsumerFactory.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/ConsumerFactory.java
@@ -17,11 +17,13 @@
 
 package org.apache.rocketmq.factory;
 
+import org.apache.rocketmq.client.consumer.AllocateMessageQueueStrategy;
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
 import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.utils.RandomUtils;
 
@@ -40,6 +42,18 @@ public class ConsumerFactory {
         DefaultMQPushConsumer consumer;
         if (aclEnable) {
             consumer = new DefaultMQPushConsumer(consumerGroup, rpcHook, new AllocateMessageQueueAveragely());
+        } else {
+            consumer = new DefaultMQPushConsumer(consumerGroup);
+        }
+        consumer.setInstanceName(RandomUtils.getStringByUUID());
+        consumer.setNamesrvAddr(nsAddr);
+        return new RMQNormalConsumer(consumer);
+    }
+
+    public static RMQNormalConsumer getRMQNormalConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook,AllocateMessageQueueStrategy allocateMessageQueueStrategy) {
+        DefaultMQPushConsumer consumer;
+        if (aclEnable) {
+            consumer = new DefaultMQPushConsumer(consumerGroup, rpcHook, allocateMessageQueueStrategy);
         } else {
             consumer = new DefaultMQPushConsumer(consumerGroup);
         }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/ConsumerFactory.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/ConsumerFactory.java
@@ -50,7 +50,48 @@ public class ConsumerFactory {
         return new RMQNormalConsumer(consumer);
     }
 
-    public static RMQNormalConsumer getRMQNormalConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook,AllocateMessageQueueStrategy allocateMessageQueueStrategy) {
+    public static RMQNormalConsumer getRMQBroadCastConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook) {
+        DefaultMQPushConsumer consumer;
+        if (aclEnable) {
+            consumer = new DefaultMQPushConsumer(consumerGroup, rpcHook, new AllocateMessageQueueAveragely());
+        } else {
+            consumer = new DefaultMQPushConsumer(consumerGroup);
+        }
+        consumer.setInstanceName(RandomUtils.getStringByUUID());
+        consumer.setMessageModel(MessageModel.BROADCASTING);
+        consumer.setNamesrvAddr(nsAddr);
+        return new RMQNormalConsumer(consumer);
+    }
+
+    public static RMQNormalConsumer getRMQClusterConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook) {
+        DefaultMQPushConsumer consumer;
+        if (aclEnable) {
+            consumer = new DefaultMQPushConsumer(consumerGroup, rpcHook, new AllocateMessageQueueAveragely());
+        } else {
+            consumer = new DefaultMQPushConsumer(consumerGroup);
+        }
+        consumer.setInstanceName(RandomUtils.getStringByUUID());
+        consumer.setMessageModel(MessageModel.CLUSTERING);
+        consumer.setNamesrvAddr(nsAddr);
+        return new RMQNormalConsumer(consumer);
+    }
+
+    public static RMQNormalConsumer getRMQClusterConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook,
+            AllocateMessageQueueStrategy allocateMessageQueueStrategy) {
+        DefaultMQPushConsumer consumer;
+        if (aclEnable) {
+            consumer = new DefaultMQPushConsumer(consumerGroup, rpcHook, allocateMessageQueueStrategy);
+        } else {
+            consumer = new DefaultMQPushConsumer(consumerGroup);
+        }
+        consumer.setInstanceName(RandomUtils.getStringByUUID());
+        consumer.setMessageModel(MessageModel.CLUSTERING);
+        consumer.setNamesrvAddr(nsAddr);
+        return new RMQNormalConsumer(consumer);
+    }
+
+    public static RMQNormalConsumer getRMQNormalConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook,
+            AllocateMessageQueueStrategy allocateMessageQueueStrategy) {
         DefaultMQPushConsumer consumer;
         if (aclEnable) {
             consumer = new DefaultMQPushConsumer(consumerGroup, rpcHook, allocateMessageQueueStrategy);
@@ -62,7 +103,7 @@ public class ConsumerFactory {
         return new RMQNormalConsumer(consumer);
     }
 
-    public static RMQNormalConsumer getRMQLitePullConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook){
+    public static RMQNormalConsumer getRMQLitePullConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook) {
         DefaultLitePullConsumer consumer;
         if (aclEnable) {
             consumer = new DefaultLitePullConsumer(consumerGroup, rpcHook);
@@ -75,7 +116,8 @@ public class ConsumerFactory {
         return new RMQNormalConsumer(consumer);
     }
 
-    public static RMQNormalConsumer getRMQLitePullConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook, int batchSize){
+    public static RMQNormalConsumer getRMQLitePullConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook,
+            int batchSize) {
         DefaultLitePullConsumer consumer;
         if (aclEnable) {
             consumer = new DefaultLitePullConsumer(consumerGroup, rpcHook);
@@ -89,7 +131,7 @@ public class ConsumerFactory {
         return new RMQNormalConsumer(consumer);
     }
 
-    public static RMQNormalConsumer getRMQPullConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook){
+    public static RMQNormalConsumer getRMQPullConsumer(String nsAddr, String consumerGroup, RPCHook rpcHook) {
         DefaultMQPullConsumer consumer;
         if (aclEnable) {
             consumer = new DefaultMQPullConsumer(consumerGroup, rpcHook);

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/MessageFactory.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/MessageFactory.java
@@ -63,7 +63,7 @@ public class MessageFactory {
     }
 
     /**
-     * 生成一条消息，自定义topic，tags，body，检测body为null抛出异常的问题
+     * Generate a message, customize the topic, tags, body, detect the body is null throws an exception problem.
      *
      * @param topic topic
      * @return message
@@ -73,7 +73,7 @@ public class MessageFactory {
     }
 
     /**
-     * 生成一条消息，自定义topic，tags，body
+     * Generate a message, customize the topic, tags, body.
      *
      * @param topic topic
      * @return message
@@ -91,7 +91,7 @@ public class MessageFactory {
     }
 
     /**
-     * 生成一条消息，自定义topic及属性
+     * Generate a message, customize the topic and properties.
      *
      * @param topic topic
      * @return message
@@ -105,7 +105,7 @@ public class MessageFactory {
     }
 
     /**
-     * 生成一条消息，tag不设置， body使用随机字符串
+     * Generate a message with no tag and a random string for the body.
      *
      * @param topic topic
      * @return message
@@ -115,7 +115,7 @@ public class MessageFactory {
     }
 
     /**
-     * 根据tag生成一条消息， body使用随机字符串
+     * A message is generated from the tag, with the body using a random string.
      *
      * @param topic topic
      * @param tag   tag
@@ -126,10 +126,10 @@ public class MessageFactory {
     }
 
     /**
-     * 根据消息体生成一条消息，tag不设置
+     * A message is generated based on the message body. The tag is not set.
      *
      * @param topic       topic
-     * @param messageBody 消息体
+     * @param messageBody message body
      * @return message
      */
     public static Message buildOneMessageWithBody(String topic, String messageBody) {
@@ -137,11 +137,11 @@ public class MessageFactory {
     }
 
     /**
-     * 构建一条指定tag，消息body的message
+     * Builds a message specifying the tag, message body
      *
-     * @param topic 发送topic
-     * @param tag   发送tag
-     * @param body  消息体
+     * @param topic topic
+     * @param tag   tag
+     * @param body  message body
      * @return Message
      */
     public static Message buildOneMessageWithTagAndBody(String topic, String tag, String body) {
@@ -149,10 +149,10 @@ public class MessageFactory {
     }
 
     ///**
-    // * 构建指定一条指定properties，消息body的message
+    // * The build specifies a message that specifies properties, the body of the message
     // *
-    // * @param topic      发送topic
-    // * @param properties 自定义属性
+    // * @param topic      topic
+    // * @param properties custom properties
     // * @return Message
     // */
     //public static Message buildMessageWithUserProperties(String topic, HashMap<String, String> properties) {
@@ -164,8 +164,8 @@ public class MessageFactory {
     //}
     //
     /**
-     * 延时消息，单位毫秒（ms），在指定延迟时间（当前时间之后）进行投递，例如消息在3秒后投递
-     * 定时消息，单位毫秒（ms），在指定时间戳（当前时间之后）进行投递，例如2016-03-07 16:21:00投递。如果被设置成当前时间戳之前的某个时刻，消息将立即被投递给消费者。
+     * A delayed message, in milliseconds (ms), is delivered after the specified delay time (after the current time), for example, the message is delivered after 3 seconds
+     * An order message, in milliseconds (ms), is delivered in a specified timestamp (after the current time), such as 2016-03-07 16:21:00 delivery. If it is set to a time before the current timestamp, the message will be delivered to the consumer immediately.
      *
      * @param topic
      * @param level
@@ -179,16 +179,16 @@ public class MessageFactory {
     //
     //public static Message buildOneMessageWithTagAndStartDeliverTime(String topic, String tag, long time) {
     //    Message msg = new Message(topic, tag, RandomUtils.getStringByUUID().getBytes());
-    //    //发送时间
+    //    //sending time
     //    msg.putUserProperties("sendTime", String.valueOf(System.currentTimeMillis()));
-    //    //推送下发消息时间
+    //    //push message delivery time
     //    msg.putUserProperties("deliverTime", String.valueOf(time));
     //    msg.setStartDeliverTime(time);
     //    return msg;
     //}
     //
     ///**
-    // * 定时消息，单位毫秒（ms），在指定时间戳（当前时间之后）进行投递，例如2016-03-07 16:21:00投递。如果被设置成当前时间戳之前的某个时刻，消息将立即被投递给消费者。
+    // * An order message, in milliseconds (ms), is delivered in a specified timestamp (after the current time), such as 2016-03-07 16:21:00 delivery. If it is set to a time before the current timestamp, the message will be delivered to the consumer immediately.
     // *
     // * @param topic
     // * @param tag

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/MessageFactory.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/factory/MessageFactory.java
@@ -23,6 +23,7 @@ import org.apache.rocketmq.utils.RandomUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 
 public class MessageFactory {
@@ -61,6 +62,47 @@ public class MessageFactory {
         return msgList;
     }
 
+    /**
+     * 生成一条消息，自定义topic，tags，body，检测body为null抛出异常的问题
+     *
+     * @param topic topic
+     * @return message
+     */
+    public static Message buildMessage(String topic, String tags, String body) throws Exception{
+        return new Message(topic, tags, body.getBytes());
+    }
+
+    /**
+     * 生成一条消息，自定义topic，tags，body
+     *
+     * @param topic topic
+     * @return message
+     */
+    public static Message buildNormalMessage(String topic, String tags, String body){
+        return new Message(topic, tags, body.getBytes());
+    }
+
+    public static Message buildMessageWithProperty(String topic, Map<String,String> userProperties, String body){
+        Message msg = new Message(topic, body.getBytes());
+        for (Map.Entry<String, String> entry : userProperties.entrySet()) {
+            msg.putUserProperty(entry.getKey(), entry.getValue());
+        }
+        return msg;
+    }
+
+    /**
+     * 生成一条消息，自定义topic及属性
+     *
+     * @param topic topic
+     * @return message
+     */
+    public static Message buildMessageWithProperty(String topic, Map<String,String> userProperties){
+        Message msg = new Message(topic, RandomUtils.getStringByUUID().getBytes());
+        for (Map.Entry<String, String> entry : userProperties.entrySet()) {
+            msg.putUserProperty(entry.getKey(), entry.getValue());
+        }
+        return msg;
+    }
 
     /**
      * 生成一条消息，tag不设置， body使用随机字符串

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/frame/BaseOperate.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/frame/BaseOperate.java
@@ -18,6 +18,8 @@
 package org.apache.rocketmq.frame;
 
 import org.apache.rocketmq.utils.MQAdmin;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,5 +33,19 @@ public class BaseOperate extends ResourceInit {
                 logger.info("Shutdown Hook is running !");
             }
         });
+    }
+
+    protected static String getTopic(String methodName) {
+        String topic = String.format("topic_%s_%s", methodName, RandomUtils.getStringWithCharacter(6));
+        logger.info("[Topic] topic:{}, methodName:{}", topic, methodName);
+        boolean result = MQAdmin.createTopic(namesrvAddr,cluster, topic, 8);
+        Assertions.assertTrue(result, String.format("Create topic:%s failed", topic));
+        return topic;
+    }
+
+    protected static String getGroupId(String methodName) {
+        String groupId = String.format("GID_%s_%s", methodName, RandomUtils.getStringWithCharacter(6));
+        logger.info("[ConsumerGroupId] groupId:{}, methodName:{}", groupId, methodName);
+        return groupId;
     }
 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/MessageIdStore.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/MessageIdStore.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.rocketmq.listener.rmq.concurrent;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MessageIdStore {
+    private Set<String> consumedMessageIds;
+    private static MessageIdStore instance;
+
+    private MessageIdStore() {
+        consumedMessageIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    }
+
+    public static MessageIdStore getInstance() {
+        if (instance == null) {
+            synchronized (MessageIdStore.class) {
+                if (instance == null) {
+                    instance = new MessageIdStore();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public boolean isMessageConsumed(String messageId) {
+        return consumedMessageIds.contains(messageId);
+    }
+
+    public void markMessageAsConsumed(String messageId) {
+        consumedMessageIds.add(messageId);
+    }
+
+    public void clear() {
+        consumedMessageIds.clear();
+    }
+}

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQIdempotentListener.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQIdempotentListener.java
@@ -38,21 +38,22 @@ public class RMQIdempotentListener extends AbstractListener implements MessageLi
 
     public RMQIdempotentListener() {
         this.listenerName = RandomUtils.getStringByUUID();
-        logger.info("启动监听:{}", listenerName);
+        logger.info("Start listening:{}", listenerName);
     }
 
     public RMQIdempotentListener(String listenerName) {
         this.listenerName = listenerName;
-        logger.info("启动监听:{}", listenerName);
+        logger.info("Start listening:{}", listenerName);
     }
 
     public RMQIdempotentListener(ConsumeConcurrentlyStatus consumeStatus) {
         this.consumeStatus = consumeStatus;
         this.listenerName = RandomUtils.getStringByUUID();
-        logger.info("启动监听:{}", listenerName);
+        logger.info("Start listening:{}", listenerName);
     }
 
-    public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs, ConsumeConcurrentlyContext consumeConcurrentlyContext) {
+    public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
+            ConsumeConcurrentlyContext consumeConcurrentlyContext) {
         for (MessageExt message : msgs) {
             boolean isConsumed = messageIdStore.isMessageConsumed(message.getMsgId());
             if (isConsumed) {
@@ -62,8 +63,10 @@ public class RMQIdempotentListener extends AbstractListener implements MessageLi
                 message.putUserProperty("startDeliverTime", String.valueOf(System.currentTimeMillis()));
                 this.dequeueAllMessages.addData(message);
                 this.dequeueMessages.addData(message);
-                logger.info("{} - MessageId:{}, ReconsumeTimes:{}, Body:{}, tag:{}, recvIndex:{}, action:{}", listenerName, message.getMsgId(),
-                    message.getReconsumeTimes(), new String(message.getBody()), message.getTags(), msgIndex.getAndIncrement() + 1, consumeStatus);
+                logger.info("{} - MessageId:{}, ReconsumeTimes:{}, Body:{}, tag:{}, recvIndex:{}, action:{}",
+                        listenerName, message.getMsgId(),
+                        message.getReconsumeTimes(), new String(message.getBody()), message.getTags(),
+                        msgIndex.getAndIncrement() + 1, consumeStatus);
                 messageIdStore.markMessageAsConsumed(message.getMsgId());
             }
         }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQIdempotentListener.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQIdempotentListener.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.rocketmq.listener.rmq.concurrent;
+
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.listener.AbstractListener;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RMQIdempotentListener extends AbstractListener implements MessageListenerConcurrently {
+    private static Logger logger = LoggerFactory.getLogger(RMQNormalListener.class);
+    private ConsumeConcurrentlyStatus consumeStatus = ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+    private AtomicInteger msgIndex = new AtomicInteger(0);
+    private String listenerName;
+    private MessageIdStore messageIdStore = MessageIdStore.getInstance();
+
+    public RMQIdempotentListener() {
+        this.listenerName = RandomUtils.getStringByUUID();
+        logger.info("启动监听:{}", listenerName);
+    }
+
+    public RMQIdempotentListener(String listenerName) {
+        this.listenerName = listenerName;
+        logger.info("启动监听:{}", listenerName);
+    }
+
+    public RMQIdempotentListener(ConsumeConcurrentlyStatus consumeStatus) {
+        this.consumeStatus = consumeStatus;
+        this.listenerName = RandomUtils.getStringByUUID();
+        logger.info("启动监听:{}", listenerName);
+    }
+
+    public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs, ConsumeConcurrentlyContext consumeConcurrentlyContext) {
+        for (MessageExt message : msgs) {
+            boolean isConsumed = messageIdStore.isMessageConsumed(message.getMsgId());
+            if (isConsumed) {
+                return consumeStatus;
+            } else {
+                msgIndex.getAndIncrement();
+                message.putUserProperty("startDeliverTime", String.valueOf(System.currentTimeMillis()));
+                this.dequeueAllMessages.addData(message);
+                this.dequeueMessages.addData(message);
+                logger.info("{} - MessageId:{}, ReconsumeTimes:{}, Body:{}, tag:{}, recvIndex:{}, action:{}", listenerName, message.getMsgId(),
+                    message.getReconsumeTimes(), new String(message.getBody()), message.getTags(), msgIndex.getAndIncrement() + 1, consumeStatus);
+                messageIdStore.markMessageAsConsumed(message.getMsgId());
+            }
+        }
+        return consumeStatus;
+    }
+}

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQNormalListener.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQNormalListener.java
@@ -40,6 +40,11 @@ public class RMQNormalListener extends AbstractListener implements MessageListen
         logger.info("启动监听:{}", listenerName);
     }
 
+    public RMQNormalListener(String listenerName) {
+        this.listenerName = listenerName;
+        logger.info("启动监听:{}", listenerName);
+    }
+
     public RMQNormalListener(ConsumeConcurrentlyStatus consumeStatus) {
         this.consumeStatus = consumeStatus;
         this.listenerName = RandomUtils.getStringByUUID();

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQNormalListener.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQNormalListener.java
@@ -37,18 +37,18 @@ public class RMQNormalListener extends AbstractListener implements MessageListen
 
     public RMQNormalListener() {
         this.listenerName = RandomUtils.getStringByUUID();
-        logger.info("启动监听:{}", listenerName);
+        logger.info("Start listening:{}", listenerName);
     }
 
     public RMQNormalListener(String listenerName) {
         this.listenerName = listenerName;
-        logger.info("启动监听:{}", listenerName);
+        logger.info("Start listening:{}", listenerName);
     }
 
     public RMQNormalListener(ConsumeConcurrentlyStatus consumeStatus) {
         this.consumeStatus = consumeStatus;
         this.listenerName = RandomUtils.getStringByUUID();
-        logger.info("启动监听:{}", listenerName);
+        logger.info("Start listening:{}", listenerName);
     }
 
     public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs, ConsumeConcurrentlyContext consumeConcurrentlyContext) {

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQOrderListener.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/RMQOrderListener.java
@@ -37,13 +37,13 @@ public class RMQOrderListener extends AbstractListener implements MessageListene
 
     public RMQOrderListener() {
         this.listenerName = RandomUtils.getStringByUUID();
-        logger.info("启动监听:{}", listenerName);
+        logger.info("Start listening:{}", listenerName);
     }
 
     public RMQOrderListener(ConsumeOrderlyStatus consumeStatus) {
         this.consumeStatus = consumeStatus;
         this.listenerName = RandomUtils.getStringByUUID();
-        logger.info("启动监听:{}", listenerName);
+        logger.info("Start listening:{}", listenerName);
     }
 
     @Override

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/TransactionListenerImpl.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/TransactionListenerImpl.java
@@ -40,8 +40,6 @@ public class TransactionListenerImpl extends AbstractListener implements Transac
 
     private ConcurrentHashMap<String, Integer> localTrans = new ConcurrentHashMap<>();
 
-
-
     public TransactionListenerImpl() {
         this.checkerName = RandomUtils.getStringByUUID();
         logger.info("启动监听:{}", checkerName);
@@ -58,42 +56,44 @@ public class TransactionListenerImpl extends AbstractListener implements Transac
     public LocalTransactionState executeLocalTransaction(Message message, Object arg) {
         logger.warn("TransactionId:{}, transactionStatus:{}", message.getTransactionId(), executor.name());
 
-        //int value = transactionIndex.getAndIncrement();
-        //int status = value % 3;
-        //localTrans.put(message.getTransactionId(), status);
+        // int value = transactionIndex.getAndIncrement();
+        // int status = value % 3;
+        // localTrans.put(message.getTransactionId(), status);
         return executor;
     }
 
     @Override
     public LocalTransactionState checkLocalTransaction(MessageExt message) {
 
-        //if (checkTimes == 1) {
-        //    //消息 ID（有可能消息体一样，但消息 ID 不一样，当前消息属于半事务消息，所以消息 ID 在控制台无法查询）
-        //    String msgId = message.getMsgId();
-        //    logger.info("checker:{}, MessageId:{}, transactionStatus:{}", checkerName, msgId, checker.name());
-        //    return checker;
-        //}
-        //if (new String(message.getBody()).equals(new String(sendMsg.getBody()))) {
-        //    checkNum++;
-        //    //check次数达到预期，则提交
-        //    if (checkNum == checkTimes) {
-        //        checker = LocalTransactionState.COMMIT_MESSAGE;
-        //    }
-        //    logger.info("checkerName:{}, MessageId:{}, status:{}, checkedTimes:{}, expectCheckNum:{}", checkerName, message.getMsgId(), checker, checkTimes,
-        //        checkNum);
-        //}
-        //Integer status = localTrans.get(message.getTransactionId());
-        //if (null != status) {
-        //    switch (status) {
-        //        case 0:
-        //            return LocalTransactionState.UNKNOW;
-        //        case 1:
-        //            return LocalTransactionState.COMMIT_MESSAGE;
-        //        case 2:
-        //            return LocalTransactionState.ROLLBACK_MESSAGE;
-        //    }
-        //}
-        //本地事务已成功则提交消息
+        // if (checkTimes == 1) {
+        // //消息 ID（有可能消息体一样，但消息 ID 不一样，当前消息属于半事务消息，所以消息 ID 在控制台无法查询）
+        // String msgId = message.getMsgId();
+        // logger.info("checker:{}, MessageId:{}, transactionStatus:{}", checkerName,
+        // msgId, checker.name());
+        // return checker;
+        // }
+        // if (new String(message.getBody()).equals(new String(sendMsg.getBody()))) {
+        // checkNum++;
+        // //check次数达到预期，则提交
+        // if (checkNum == checkTimes) {
+        // checker = LocalTransactionState.COMMIT_MESSAGE;
+        // }
+        // logger.info("checkerName:{}, MessageId:{}, status:{}, checkedTimes:{},
+        // expectCheckNum:{}", checkerName, message.getMsgId(), checker, checkTimes,
+        // checkNum);
+        // }
+        // Integer status = localTrans.get(message.getTransactionId());
+        // if (null != status) {
+        // switch (status) {
+        // case 0:
+        // return LocalTransactionState.UNKNOW;
+        // case 1:
+        // return LocalTransactionState.COMMIT_MESSAGE;
+        // case 2:
+        // return LocalTransactionState.ROLLBACK_MESSAGE;
+        // }
+        // }
+        // 本地事务已成功则提交消息
         return checker;
     }
 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/TransactionListenerImpl.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/listener/rmq/concurrent/TransactionListenerImpl.java
@@ -42,14 +42,14 @@ public class TransactionListenerImpl extends AbstractListener implements Transac
 
     public TransactionListenerImpl() {
         this.checkerName = RandomUtils.getStringByUUID();
-        logger.info("启动监听:{}", checkerName);
+        logger.info("Start listening:{}", checkerName);
     }
 
     public TransactionListenerImpl(LocalTransactionState checker, LocalTransactionState executor) {
         this.checkerName = RandomUtils.getStringByUUID();
         this.checker = checker;
         this.executor = executor;
-        logger.info("启动监听:{}", checkerName);
+        logger.info("Start listening:{}", checkerName);
     }
 
     @Override

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/AssertUtils.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/AssertUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class AssertUtils {
+    private static final Logger log = LoggerFactory.getLogger(AssertUtils.class);
+//    final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+
+    public static void assertConcurrent(final String message, final List<? extends Runnable> runnables,
+        final int maxTimeoutSeconds) throws InterruptedException {
+        final int numThreads = runnables.size();
+        final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
+        final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+        try {
+            final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
+            final CountDownLatch afterInitBlocker = new CountDownLatch(1);
+            final CountDownLatch allDone = new CountDownLatch(numThreads);
+            for (final Runnable submittedTestRunnable : runnables) {
+                threadPool.submit(new Runnable() {
+                    public void run() {
+                        allExecutorThreadsReady.countDown();
+                        try {
+                            afterInitBlocker.await();
+                            submittedTestRunnable.run();
+                        } catch (final Throwable e) {
+                            exceptions.add(e);
+                        } finally {
+                            allDone.countDown();
+                        }
+                    }
+                });
+            }
+            // wait until all threads are ready
+            Assertions.assertTrue(allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS), "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent");
+            // start all test runners
+            afterInitBlocker.countDown();
+            Assertions.assertTrue(allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS), message + " timeout! More than " + maxTimeoutSeconds + " seconds");
+        } finally {
+            log.info("exit sub thread");
+            threadPool.shutdown();
+        }
+        Assertions.assertTrue(exceptions.isEmpty(), message + " failed with exception(s)" + exceptions);
+    }
+
+    public static void assertConcurrentAtMost(final String message, final List<? extends Runnable> runnables,
+        final int maxTimeoutSeconds) throws InterruptedException {
+        final int numThreads = runnables.size();
+        final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
+        final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+        try {
+            final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
+            final CountDownLatch afterInitBlocker = new CountDownLatch(1);
+            final CountDownLatch allDone = new CountDownLatch(numThreads);
+            for (final Runnable submittedTestRunnable : runnables) {
+                threadPool.submit(new Runnable() {
+                    public void run() {
+                        allExecutorThreadsReady.countDown();
+                        try {
+                            afterInitBlocker.await();
+                            submittedTestRunnable.run();
+                        } catch (final Throwable e) {
+                            exceptions.add(e);
+                        } finally {
+                            allDone.countDown();
+                        }
+                    }
+                });
+            }
+            // wait until all threads are ready
+            Assertions.assertTrue(allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS), "Timeout initializing threads! Perform long lasting initializations before passing runnables to assertConcurrent");
+            // start all test runners
+            afterInitBlocker.countDown();
+            allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS);
+//            Assertions.assertTrue(allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS), message + " timeout! More than " + maxTimeoutSeconds + " seconds");
+        } finally {
+            log.info("exit sub thread");
+            threadPool.shutdown();
+        }
+        Assertions.assertTrue(exceptions.isEmpty(), message + " failed with exception(s)" + exceptions);
+    }
+}

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/DateUtils.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/DateUtils.java
@@ -27,9 +27,9 @@ public class DateUtils {
 
 
     /**
-     * 获取当前时间的秒级偏移时间
-     * offset=10 10秒后  offset=-10 10秒前
-     * @param offset 偏移时间
+     * Gets the second-level offset time of the current time
+     * offset=10 (10 seconds later)  offset=-10 (10 seconds before)
+     * @param offset Offset time
      * @return
      */
     public static long getCurrentTimeOffsetBySecond(int offset) {
@@ -47,9 +47,9 @@ public class DateUtils {
     }
 
     /**
-     * 获取当前时间的分钟级偏移时间
+     * Gets the minute-level offset time of the current time
      *
-     * @param offset 偏移时间
+     * @param offset Offset time
      * @return
      */
     public static long getCurrentTimeOffsetByMin(int offset) {
@@ -66,9 +66,9 @@ public class DateUtils {
     }
 
     /**
-     * 获取当前时间的小时级偏移时间
+     * Gets the hour level offset time of the current time
      *
-     * @param offset 偏移时间
+     * @param offset Offset time
      * @return
      */
     public static long getCurrentTimeOffsetByHour(int offset) {
@@ -85,9 +85,9 @@ public class DateUtils {
     }
 
     /**
-     * 获取当前时间的天级偏移时间
+     * Gets the day offset time of the current time
      *
-     * @param offset 偏移时间
+     * @param offset Offset time
      * @return
      */
     public static long getCurrentTimeOffsetByDay(int offset) {
@@ -104,9 +104,9 @@ public class DateUtils {
     }
 
     /**
-     * 格式化时间戳
+     * Formatting timestamp
      *
-     * @param time 偏移时间
+     * @param time Offset time
      * @return
      */
     public static String format(long time) {

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/FilterUtils.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/FilterUtils.java
@@ -24,24 +24,26 @@ import java.util.Set;
 
 public class FilterUtils {
     private static final Logger log = LoggerFactory.getLogger(AssertUtils.class);
-    //自定义用于pullconsumer过滤tag使用
-    public static boolean inTags(String msgTag,String tags){
+
+    // 自定义用于pullconsumer过滤tag使用
+    public static boolean inTags(String msgTag, String tags) {
         if (null == tags || tags.equals("*") || tags.length() == 0) {
             return true;
         } else {
-            //分割
+            // 分割
             String[] tag_splits = tags.split("\\|\\|");
             Set<Integer> tagSet = new HashSet<>();
             if (tag_splits.length > 0) {
                 for (String tag : tag_splits) {
                     if (tag.length() > 0) {
-                        if("*".equals(tag)) return true;
+                        if ("*".equals(tag))
+                            return true;
                         String trimString = tag.trim();
                         if (trimString.length() > 0) {
                             tagSet.add(trimString.hashCode());
                         }
                     }
-                    if(tagSet.contains(msgTag.hashCode())){
+                    if (tagSet.contains(msgTag.hashCode())) {
                         return true;
                     }
                 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/FilterUtils.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/FilterUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class FilterUtils {
+    private static final Logger log = LoggerFactory.getLogger(AssertUtils.class);
+    //自定义用于pullconsumer过滤tag使用
+    public static boolean inTags(String msgTag,String tags){
+        if (null == tags || tags.equals("*") || tags.length() == 0) {
+            return true;
+        } else {
+            //分割
+            String[] tag_splits = tags.split("\\|\\|");
+            Set<Integer> tagSet = new HashSet<>();
+            if (tag_splits.length > 0) {
+                for (String tag : tag_splits) {
+                    if (tag.length() > 0) {
+                        if("*".equals(tag)) return true;
+                        String trimString = tag.trim();
+                        if (trimString.length() > 0) {
+                            tagSet.add(trimString.hashCode());
+                        }
+                    }
+                    if(tagSet.contains(msgTag.hashCode())){
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/FilterUtils.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/FilterUtils.java
@@ -25,12 +25,12 @@ import java.util.Set;
 public class FilterUtils {
     private static final Logger log = LoggerFactory.getLogger(AssertUtils.class);
 
-    // 自定义用于pullconsumer过滤tag使用
+    // Custom used to filter tag for pullconsumer
     public static boolean inTags(String msgTag, String tags) {
         if (null == tags || tags.equals("*") || tags.length() == 0) {
             return true;
         } else {
-            // 分割
+            // partition
             String[] tag_splits = tags.split("\\|\\|");
             Set<Integer> tagSet = new HashSet<>();
             if (tag_splits.length > 0) {

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/NameUtils.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/NameUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.utils;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.Map;
@@ -59,6 +60,31 @@ public class NameUtils {
             }
         }
 
+    }
+
+    public synchronized static String getRandomTagName() {
+        while (true) {
+            String tag = "tag-server-" + RandomStringUtils.randomAlphanumeric(20);
+            String used = alreadyUsed.putIfAbsent(tag, tag);
+            if (used == null) {
+                return tag;
+            }
+        }
+    }
+
+    public synchronized static String getRandomGroupName() {
+        while (true) {
+            String gid = "GID-server-" + RandomStringUtils.randomAlphanumeric(20);
+            String used = alreadyUsed.putIfAbsent(gid, gid);
+            if (used == null) {
+                return gid;
+            }
+        }
+    }
+
+    protected static String getMD5Sum(String className, String methodName) {
+        String completeName = String.format("%s-%s", className, methodName);
+        return methodName + "-" + DigestUtils.md5Hex(completeName).substring(0, 6);
     }
 
 }

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/TestUtils.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/TestUtils.java
@@ -106,7 +106,8 @@ public class TestUtils {
             byte[] b = new byte[1024];
             int n = System.in.read(b);
 
-            for (String s = (new String(b, 0, n - 1)).replace("\r", "").replace("\n", ""); !s.equals(keyWord); s = new String(b, 0, n - 1)) {
+            for (String s = (new String(b, 0, n - 1)).replace("\r", "").replace("\n", ""); !s
+                    .equals(keyWord); s = new String(b, 0, n - 1)) {
                 n = System.in.read(b);
             }
 
@@ -121,14 +122,14 @@ public class TestUtils {
         Collections.sort(list, new Comparator<Map.Entry<K, V>>() {
             @Override
             public int compare(Map.Entry<K, V> o1, Map.Entry<K, V> o2) {
-                return ((Comparable)o1.getValue()).compareTo(o2.getValue());
+                return ((Comparable) o1.getValue()).compareTo(o2.getValue());
             }
         });
         Map<K, V> result = new LinkedHashMap();
         Iterator var3 = list.iterator();
 
         while (var3.hasNext()) {
-            Map.Entry<K, V> entry = (Map.Entry)var3.next();
+            Map.Entry<K, V> entry = (Map.Entry) var3.next();
             result.put(entry.getKey(), entry.getValue());
         }
 

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/DataCollector.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/DataCollector.java
@@ -20,73 +20,73 @@ package org.apache.rocketmq.utils.data.collect;
 import java.util.Collection;
 public interface DataCollector<T> {
     /**
-     * 计数归零
+     * reset datas' size to zero
      */
     void resetData();
 
     /**
-     * 取得所有的收集数据，包含重复的数据
+     * Get all collected data, including duplicate data
      *
      * @return
      */
     Collection<T> getAllData();
 
     /**
-     * 取得收集的非重复数据
+     * Get collected non-duplicate data
      *
      * @return
      */
     Collection<T> getAllDataWithoutDuplicate();
 
     /**
-     * 增加数据
+     * Add data
      */
     void addData(T data);
 
     /**
-     * 取得非重复数据的总个数
+     * Gets the total number of non-duplicate data
      *
      * @return
      */
     long getDataSizeWithoutDuplicate();
 
     /**
-     * 取得所有数据的总个数，包括重复数据
+     * Gets the total number of all data, including duplicates
      *
      * @return
      */
     long getDataSize();
 
     /**
-     * 验证一条数据是否存在重复
+     * Verify that a piece of data is duplicated
      *
      * @return
      */
     boolean isRepeatedData(T data);
 
     /**
-     * 取得一条数据重复出现的次数
+     * Gets the number of times a piece of data is repeated
      *
      * @return
      */
     int getRepeatedTimeForData(T data);
 
     /**
-     * 移除一条数据
+     * Remove a piece of data
      *
      * @return
      */
     void removeData(T data);
 
     /**
-     * 锁定计数器，使其不再增加，但是可以删除
+     * Lock the counter so that it no longer increases, but can be deleted
      *
      * @return
      */
     void lockIncrement();
 
     /**
-     * 接触计数器锁定，使其可以增加和删除
+     * The contact counter locks so that it can be added and removed
      *
      * @return
      */

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/DataCollectorManager.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/DataCollectorManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.utils.data.collect;
 
-
 import org.apache.rocketmq.utils.data.collect.impl.ListDataCollectorImpl;
 import org.apache.rocketmq.utils.data.collect.impl.MapDataCollectorImpl;
 

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/impl/ListDataCollectorImpl.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/impl/ListDataCollectorImpl.java
@@ -24,6 +24,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 
 public class ListDataCollectorImpl implements DataCollector {

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/impl/ListDataCollectorImpl.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/impl/ListDataCollectorImpl.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-
 public class ListDataCollectorImpl implements DataCollector {
 
     private List<Object> datas = new ArrayList<Object>();

--- a/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/impl/MapDataCollectorImpl.java
+++ b/java/e2e-v4/src/main/java/org/apache/rocketmq/utils/data/collect/impl/MapDataCollectorImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.utils.data.collect.impl;
 
-
 import org.apache.rocketmq.utils.data.collect.DataCollector;
 
 import java.util.ArrayList;

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/ConsumerGroupTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/ConsumerGroupTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.consumer;
+
+
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag(TESTSET.CLIENT)
+@Tag(TESTSET.SMOKE)
+public class ConsumerGroupTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(ConsumerGroupTest.class);
+    private static String topic;
+    private static String className;
+    private DefaultLitePullConsumer consumer;
+
+    @BeforeAll
+    public static void setUpAll() {
+        className = ConsumerGroupTest.class.getName();
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        topic = getTopic(methodName);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (consumer != null) {
+            consumer.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("Use the built-in ConsumerGroup[DEFAULT_CONSUMER] to consume messages and expect consume failed")
+    public void testSystemInnerConsumerGroup() {
+        String groupId = "DEFAULT_CONSUMER";
+        assertThrows(Exception.class, () -> {
+            consumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            consumer.setNamesrvAddr(namesrvAddr);
+            consumer.subscribe(topic, "*");
+            consumer.setPullBatchSize(20);
+            consumer.start();
+            while (true) {
+                List<MessageExt> messageExts = consumer.poll();
+                log.info("MessageExt: {}",messageExts);
+            }
+        }, "Expected Start [SimpleConsumer] Exception to throw, but it didn't");
+    }
+
+}

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/ConsumerGroupTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/ConsumerGroupTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.client.consumer;
 
-
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.enums.TESTSET;
 import org.apache.rocketmq.frame.BaseOperate;
@@ -30,7 +29,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(TESTSET.CLIENT)
-@Tag(TESTSET.SMOKE)
 public class ConsumerGroupTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(ConsumerGroupTest.class);
     private static String topic;
@@ -56,14 +54,14 @@ public class ConsumerGroupTest extends BaseOperate {
     public void testSystemInnerConsumerGroup() {
         String groupId = "DEFAULT_CONSUMER";
         assertThrows(Exception.class, () -> {
-            consumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            consumer = new DefaultLitePullConsumer(groupId, rpcHook);
             consumer.setNamesrvAddr(namesrvAddr);
             consumer.subscribe(topic, "*");
             consumer.setPullBatchSize(20);
             consumer.start();
             while (true) {
                 List<MessageExt> messageExts = consumer.poll();
-                log.info("MessageExt: {}",messageExts);
+                log.info("MessageExt: {}", messageExts);
             }
         }, "Expected Start [SimpleConsumer] Exception to throw, but it didn't");
     }

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PullConsumerInitTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PullConsumerInitTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.consumer;
+
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag(TESTSET.CLIENT)
+@Tag(TESTSET.SMOKE)
+public class PullConsumerInitTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(PullConsumerInitTest.class);
+    private static String topic;
+    private static String groupId;
+
+    @BeforeAll
+    public static void setUpAll() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        topic = getTopic(methodName);
+        groupId = getGroupId(methodName);
+    }
+
+    @BeforeEach
+    public void setUp() {
+
+    }
+
+    @AfterEach
+    public void tearDown() {
+    }
+
+    @AfterAll
+    public static void tearDownAll() {
+    }
+
+    @Test
+    @DisplayName("PullConsumer all parameters are set properly, expect start success")
+    public void testNormalSetting() {
+        try {
+            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            pullConsumer.setNamesrvAddr(namesrvAddr);
+            pullConsumer.subscribe(topic, "*");
+            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.start();
+            pullConsumer.shutdown();
+        } catch (Exception e) {
+            Assertions.fail("Start [PullConsumer] failed, expected success, message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("Without setting 'Endpoint Configuration' of the consumer client, expect start failed")
+    public void testNoClientConfiguration() {
+        assertThrows(Exception.class, () -> {
+            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId);
+            pullConsumer.subscribe(topic, "*");
+            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.start();
+        }, "Expected Start [PullConsumer] Exception to throw, but it didn't");
+    }
+
+    @Test
+    @DisplayName("Without setting 'ConsumerGroup' of the consumer client, expect start failed")
+    public void testNoConsumerGroup() {
+        assertThrows(Exception.class, () -> {
+            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(rpcHook);
+            pullConsumer.setNamesrvAddr(namesrvAddr);
+            pullConsumer.subscribe(topic, "*");
+            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.start();
+        }, "Expected Start [PullConsumer] Exception to throw, but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("Without setting 'Subscription' of the consumer client, expect start failed")
+    public void testNoSubscription() {
+        assertThrows(Exception.class, () -> {
+            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            pullConsumer.setNamesrvAddr(namesrvAddr);
+            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.start();
+        }, "Expected Start [PullConsumer] Exception to throw, but it didn't");
+    }
+
+    @Test
+    @DisplayName("Error setting 'SubscriptionExpressions' empty of the consumer client, except start failed")
+    public void testEmptySubscription() {
+        assertThrows(Exception.class, () -> {
+            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            pullConsumer.setNamesrvAddr(namesrvAddr);
+            String var1 = null;
+            String var2 = null;
+            pullConsumer.subscribe(var1, var2);
+            pullConsumer.start();
+        }, "Expected Start [PullConsumer] Exception to throw, but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("Error setting 'ConsumerPullTimeoutMillis=0' of the consumer client, except start failed")
+    public void testConsumerPullTimeoutMillisIs0s() {
+        DefaultLitePullConsumer pullConsumer = null;
+        try{
+            pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            pullConsumer.setNamesrvAddr(namesrvAddr);
+            pullConsumer.subscribe(topic,"*");
+            pullConsumer.setConsumerPullTimeoutMillis(0*1000);
+            pullConsumer.start();
+            pullConsumer.poll();
+        }catch (Exception e){
+            e.printStackTrace();
+            Assertions.fail("PullConsumer start failed");
+        }
+    }
+
+
+    @Test
+    @DisplayName("Setting 'Wait Duration = 10s',Expect the empty pull message request to return between 10s and 20s")
+    public void testAwaitDuration() {
+        DefaultLitePullConsumer pullConsumer = null;
+        try {
+            pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            pullConsumer.setNamesrvAddr(namesrvAddr);
+            pullConsumer.subscribe(topic,"*");
+            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.start();
+            long startTime = System.currentTimeMillis();
+            log.info("startTime: {}", startTime);
+            pullConsumer.poll(10*1000);
+            long endTime = System.currentTimeMillis();
+            log.info("endTime: {}", endTime);
+            pullConsumer.shutdown();
+            Assertions.assertTrue((endTime - startTime) > 10000 && (endTime - startTime) < 20000, String.format("invoke method 'receive()' exception, startTime:%s, endTime:%s, intervalTime:%s", startTime, endTime, endTime - startTime));
+        } catch (Exception e) {
+            Assertions.fail("PullConsumer start exception");
+        }
+    }
+}

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PullConsumerInitTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PullConsumerInitTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(TESTSET.CLIENT)
-@Tag(TESTSET.SMOKE)
 public class PullConsumerInitTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(PullConsumerInitTest.class);
     private static String topic;
@@ -61,10 +60,10 @@ public class PullConsumerInitTest extends BaseOperate {
     @DisplayName("PullConsumer all parameters are set properly, expect start success")
     public void testNormalSetting() {
         try {
-            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId, rpcHook);
             pullConsumer.setNamesrvAddr(namesrvAddr);
             pullConsumer.subscribe(topic, "*");
-            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.setConsumerPullTimeoutMillis(10 * 1000);
             pullConsumer.start();
             pullConsumer.shutdown();
         } catch (Exception e) {
@@ -78,7 +77,7 @@ public class PullConsumerInitTest extends BaseOperate {
         assertThrows(Exception.class, () -> {
             DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId);
             pullConsumer.subscribe(topic, "*");
-            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.setConsumerPullTimeoutMillis(10 * 1000);
             pullConsumer.start();
         }, "Expected Start [PullConsumer] Exception to throw, but it didn't");
     }
@@ -90,7 +89,7 @@ public class PullConsumerInitTest extends BaseOperate {
             DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(rpcHook);
             pullConsumer.setNamesrvAddr(namesrvAddr);
             pullConsumer.subscribe(topic, "*");
-            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.setConsumerPullTimeoutMillis(10 * 1000);
             pullConsumer.start();
         }, "Expected Start [PullConsumer] Exception to throw, but it didn't");
     }
@@ -99,9 +98,9 @@ public class PullConsumerInitTest extends BaseOperate {
     @DisplayName("Without setting 'Subscription' of the consumer client, expect start failed")
     public void testNoSubscription() {
         assertThrows(Exception.class, () -> {
-            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId, rpcHook);
             pullConsumer.setNamesrvAddr(namesrvAddr);
-            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.setConsumerPullTimeoutMillis(10 * 1000);
             pullConsumer.start();
         }, "Expected Start [PullConsumer] Exception to throw, but it didn't");
     }
@@ -110,7 +109,7 @@ public class PullConsumerInitTest extends BaseOperate {
     @DisplayName("Error setting 'SubscriptionExpressions' empty of the consumer client, except start failed")
     public void testEmptySubscription() {
         assertThrows(Exception.class, () -> {
-            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            DefaultLitePullConsumer pullConsumer = new DefaultLitePullConsumer(groupId, rpcHook);
             pullConsumer.setNamesrvAddr(namesrvAddr);
             String var1 = null;
             String var2 = null;
@@ -123,37 +122,38 @@ public class PullConsumerInitTest extends BaseOperate {
     @DisplayName("Error setting 'ConsumerPullTimeoutMillis=0' of the consumer client, except start failed")
     public void testConsumerPullTimeoutMillisIs0s() {
         DefaultLitePullConsumer pullConsumer = null;
-        try{
-            pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+        try {
+            pullConsumer = new DefaultLitePullConsumer(groupId, rpcHook);
             pullConsumer.setNamesrvAddr(namesrvAddr);
-            pullConsumer.subscribe(topic,"*");
-            pullConsumer.setConsumerPullTimeoutMillis(0*1000);
+            pullConsumer.subscribe(topic, "*");
+            pullConsumer.setConsumerPullTimeoutMillis(0 * 1000);
             pullConsumer.start();
             pullConsumer.poll();
-        }catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             Assertions.fail("PullConsumer start failed");
         }
     }
-
 
     @Test
     @DisplayName("Setting 'Wait Duration = 10s',Expect the empty pull message request to return between 10s and 20s")
     public void testAwaitDuration() {
         DefaultLitePullConsumer pullConsumer = null;
         try {
-            pullConsumer = new DefaultLitePullConsumer(groupId,rpcHook);
+            pullConsumer = new DefaultLitePullConsumer(groupId, rpcHook);
             pullConsumer.setNamesrvAddr(namesrvAddr);
-            pullConsumer.subscribe(topic,"*");
-            pullConsumer.setConsumerPullTimeoutMillis(10*1000);
+            pullConsumer.subscribe(topic, "*");
+            pullConsumer.setConsumerPullTimeoutMillis(10 * 1000);
             pullConsumer.start();
             long startTime = System.currentTimeMillis();
             log.info("startTime: {}", startTime);
-            pullConsumer.poll(10*1000);
+            pullConsumer.poll(10 * 1000);
             long endTime = System.currentTimeMillis();
             log.info("endTime: {}", endTime);
             pullConsumer.shutdown();
-            Assertions.assertTrue((endTime - startTime) > 10000 && (endTime - startTime) < 20000, String.format("invoke method 'receive()' exception, startTime:%s, endTime:%s, intervalTime:%s", startTime, endTime, endTime - startTime));
+            Assertions.assertTrue((endTime - startTime) > 10000 && (endTime - startTime) < 20000,
+                    String.format("invoke method 'receive()' exception, startTime:%s, endTime:%s, intervalTime:%s",
+                            startTime, endTime, endTime - startTime));
         } catch (Exception e) {
             Assertions.fail("PullConsumer start exception");
         }

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PushConsumerInitTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PushConsumerInitTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.consumer;
+
+
+import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.utils.TestUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * PushConsumer client initialization use case
+ */
+@Tag(TESTSET.CLIENT)
+@Tag(TESTSET.SMOKE)
+public class PushConsumerInitTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(PushConsumerInitTest.class);
+    private static String topic;
+    private static String groupId;
+
+    @BeforeAll
+    public static void setUpAll() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        topic = getTopic(methodName);
+        groupId = getGroupId(methodName);
+        TestUtils.waitForSeconds(2);
+    }
+
+    @BeforeEach
+    public void setUp() {
+
+    }
+
+    @AfterEach
+    public void tearDown() {
+    }
+
+    @AfterAll
+    public static void tearDownAll() {
+    }
+
+    @Test
+    @DisplayName("PushConsumer all parameters are set properly, expect start success")
+    public void testNormalSetting() {
+        try {
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe(topic,"*");
+            pushConsumer.setConsumeThreadMax(20);
+            pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+            pushConsumer.setMessageListener(new RMQNormalListener());
+            pushConsumer.start();
+            pushConsumer.shutdown();
+        } catch (Exception e) {
+            Assertions.fail("Start [PushConsumer] failed, expected success, message: " + e.getMessage());
+        }
+    }
+
+    @Test
+    @Tag(TESTSET.ACL)
+    @DisplayName("Error setting the 'EndPoint' of the consumer client,expect start failed")
+    public void testErrorNameserver() {
+        assertThrows(Exception.class, () -> {
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            pushConsumer.setNamesrvAddr("https://www.aliyun.com");
+            pushConsumer.subscribe(topic,"*");
+            pushConsumer.setConsumeThreadMax(20);
+            pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+            pushConsumer.setMessageListener(new RMQNormalListener());
+            pushConsumer.start();
+            pushConsumer.shutdown();
+        }, "Expected Start [PushConsumer] ClientException to throw, but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("Set the consumer client's topic error, expecting a message receiving failure to throw an Exception")
+    public void testErrorTopic() {
+        assertThrows(Exception.class, () -> {
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe("topicNotExist","*");
+            pushConsumer.setConsumeThreadMax(20);
+            pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+            pushConsumer.setMessageListener(new RMQNormalListener());
+            pushConsumer.start();
+            pushConsumer.shutdown();
+        }, "Expected Start [PushConsumer] ClientException to throw, but it didn't");
+    }
+
+    @Test
+    @DisplayName("Without setting ConsumerGroup, expect PushConsumer NPE exception to start")
+    public void testNoGroupId() {
+        assertThrows(Exception.class, () -> {
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(rpcHook);
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe(topic,"*");
+            pushConsumer.setConsumeThreadMax(20);
+            pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+            pushConsumer.setMessageListener(new RMQNormalListener());
+            pushConsumer.start();
+            pushConsumer.shutdown();
+        }, "Expected Start [PushConsumer] ClientException to throw, but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("The 'Subscription' is not set, expect PushConsumer IllegalArgumentException exception to start")
+    public void testNoSubscription() {
+        assertThrows(Exception.class, () -> {
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.setConsumeThreadMax(20);
+            pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+            pushConsumer.setMessageListener(new RMQNormalListener());
+            pushConsumer.start();
+            pushConsumer.shutdown();
+        }, "Expected Start [PushConsumer] ClientException to throw, but it didn't");
+    }
+
+    @Test
+    @DisplayName("Set an empty Subscription, expecting PushConsumer IllegalArgumentException to be raised")
+    public void testEmptySubscription() {
+        assertThrows(Exception.class, () -> {
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            String var1 = null;
+            String var2 = null;
+            pushConsumer.subscribe(var1,var2);
+            pushConsumer.setConsumeThreadMax(20);
+            pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+            pushConsumer.setMessageListener(new RMQNormalListener());
+            pushConsumer.start();
+            pushConsumer.shutdown();
+        }, "Expected Start [PushConsumer] ClientException to throw, but it didn't");
+    }
+
+    @Test
+    @DisplayName("The 'Endpoint Configuration' is not set. PushConsumer IllegalState exception is expected")
+    public void testNoClientConfiguration() {
+        assertThrows(IllegalStateException.class, () -> {
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId);
+            pushConsumer.subscribe(topic,"*");
+            pushConsumer.setConsumeThreadMax(20);
+            pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+            pushConsumer.setMessageListener(new RMQNormalListener());
+            pushConsumer.start();
+            pushConsumer.shutdown();
+        }, "Expected Start [PushConsumer] ClientException to throw, but it didn't");
+    }
+
+    @Test
+    @DisplayName("The 'MessageListener' is not set. PushConsumer MQClient exception is expected")
+    public void testNoListener() {
+        assertThrows(MQClientException.class, () -> {
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe(topic,"*");
+            pushConsumer.setConsumeThreadMax(20);
+            pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+            pushConsumer.start();
+            pushConsumer.shutdown();
+        }, "Expected Start [PushConsumer] ClientException to throw, but it didn't");
+    }
+}

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PushConsumerInitTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PushConsumerInitTest.java
@@ -159,7 +159,7 @@ public class PushConsumerInitTest extends BaseOperate {
     @Test
     @DisplayName("The 'Endpoint Configuration' is not set. PushConsumer IllegalState exception is expected")
     public void testNoClientConfiguration() {
-        assertThrows(IllegalStateException.class, () -> {
+        assertThrows(Exception.class, () -> {
             DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId);
             pushConsumer.subscribe(topic,"*");
             pushConsumer.setConsumeThreadMax(20);

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PushConsumerInitTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/consumer/PushConsumerInitTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.client.consumer;
 
-
 import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
@@ -35,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * PushConsumer client initialization use case
  */
 @Tag(TESTSET.CLIENT)
-@Tag(TESTSET.SMOKE)
 public class PushConsumerInitTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(PushConsumerInitTest.class);
     private static String topic;
@@ -66,9 +64,10 @@ public class PushConsumerInitTest extends BaseOperate {
     @DisplayName("PushConsumer all parameters are set properly, expect start success")
     public void testNormalSetting() {
         try {
-            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook,
+                    new AllocateMessageQueueAveragely());
             pushConsumer.setNamesrvAddr(namesrvAddr);
-            pushConsumer.subscribe(topic,"*");
+            pushConsumer.subscribe(topic, "*");
             pushConsumer.setConsumeThreadMax(20);
             pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
             pushConsumer.setMessageListener(new RMQNormalListener());
@@ -84,9 +83,10 @@ public class PushConsumerInitTest extends BaseOperate {
     @DisplayName("Error setting the 'EndPoint' of the consumer client,expect start failed")
     public void testErrorNameserver() {
         assertThrows(Exception.class, () -> {
-            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook,
+                    new AllocateMessageQueueAveragely());
             pushConsumer.setNamesrvAddr("https://www.aliyun.com");
-            pushConsumer.subscribe(topic,"*");
+            pushConsumer.subscribe(topic, "*");
             pushConsumer.setConsumeThreadMax(20);
             pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
             pushConsumer.setMessageListener(new RMQNormalListener());
@@ -99,9 +99,10 @@ public class PushConsumerInitTest extends BaseOperate {
     @DisplayName("Set the consumer client's topic error, expecting a message receiving failure to throw an Exception")
     public void testErrorTopic() {
         assertThrows(Exception.class, () -> {
-            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook,
+                    new AllocateMessageQueueAveragely());
             pushConsumer.setNamesrvAddr(namesrvAddr);
-            pushConsumer.subscribe("topicNotExist","*");
+            pushConsumer.subscribe("topicNotExist", "*");
             pushConsumer.setConsumeThreadMax(20);
             pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
             pushConsumer.setMessageListener(new RMQNormalListener());
@@ -116,7 +117,7 @@ public class PushConsumerInitTest extends BaseOperate {
         assertThrows(Exception.class, () -> {
             DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(rpcHook);
             pushConsumer.setNamesrvAddr(namesrvAddr);
-            pushConsumer.subscribe(topic,"*");
+            pushConsumer.subscribe(topic, "*");
             pushConsumer.setConsumeThreadMax(20);
             pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
             pushConsumer.setMessageListener(new RMQNormalListener());
@@ -129,7 +130,8 @@ public class PushConsumerInitTest extends BaseOperate {
     @DisplayName("The 'Subscription' is not set, expect PushConsumer IllegalArgumentException exception to start")
     public void testNoSubscription() {
         assertThrows(Exception.class, () -> {
-            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook,
+                    new AllocateMessageQueueAveragely());
             pushConsumer.setNamesrvAddr(namesrvAddr);
             pushConsumer.setConsumeThreadMax(20);
             pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
@@ -143,11 +145,12 @@ public class PushConsumerInitTest extends BaseOperate {
     @DisplayName("Set an empty Subscription, expecting PushConsumer IllegalArgumentException to be raised")
     public void testEmptySubscription() {
         assertThrows(Exception.class, () -> {
-            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook,
+                    new AllocateMessageQueueAveragely());
             pushConsumer.setNamesrvAddr(namesrvAddr);
             String var1 = null;
             String var2 = null;
-            pushConsumer.subscribe(var1,var2);
+            pushConsumer.subscribe(var1, var2);
             pushConsumer.setConsumeThreadMax(20);
             pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
             pushConsumer.setMessageListener(new RMQNormalListener());
@@ -161,7 +164,7 @@ public class PushConsumerInitTest extends BaseOperate {
     public void testNoClientConfiguration() {
         assertThrows(Exception.class, () -> {
             DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId);
-            pushConsumer.subscribe(topic,"*");
+            pushConsumer.subscribe(topic, "*");
             pushConsumer.setConsumeThreadMax(20);
             pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
             pushConsumer.setMessageListener(new RMQNormalListener());
@@ -174,9 +177,10 @@ public class PushConsumerInitTest extends BaseOperate {
     @DisplayName("The 'MessageListener' is not set. PushConsumer MQClient exception is expected")
     public void testNoListener() {
         assertThrows(MQClientException.class, () -> {
-            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId,rpcHook,new AllocateMessageQueueAveragely());
+            DefaultMQPushConsumer pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook,
+                    new AllocateMessageQueueAveragely());
             pushConsumer.setNamesrvAddr(namesrvAddr);
-            pushConsumer.subscribe(topic,"*");
+            pushConsumer.subscribe(topic, "*");
             pushConsumer.setConsumeThreadMax(20);
             pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
             pushConsumer.start();

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageAbnormalTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageAbnormalTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Test message properties
  */
 @Tag(TESTSET.CLIENT)
-@Tag(TESTSET.SMOKE)
 public class MessageAbnormalTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(MessageAbnormalTest.class);
     private static DefaultMQProducer producer;
@@ -48,7 +47,7 @@ public class MessageAbnormalTest extends BaseOperate {
         String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
         topic = getTopic(methodName);
         try {
-            producer = new DefaultMQProducer("MessageAbnormalTest",rpcHook);
+            producer = new DefaultMQProducer("MessageAbnormalTest", rpcHook);
             producer.setNamesrvAddr(namesrvAddr);
             producer.start();
         } catch (MQClientException e) {
@@ -70,7 +69,7 @@ public class MessageAbnormalTest extends BaseOperate {
 
     }
 
-    //TODO
+    // TODO
     @Disabled
     @DisplayName("producer invoke send(messageBody=\"\"), expect throw exception")
     public void sendMsgBodyIsEmpty() {

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageAbnormalTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageAbnormalTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.message;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test message properties
+ */
+@Tag(TESTSET.CLIENT)
+@Tag(TESTSET.SMOKE)
+public class MessageAbnormalTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(MessageAbnormalTest.class);
+    private static DefaultMQProducer producer;
+    private static String topic;
+    private String tag;
+
+    @BeforeAll
+    public static void setUpAll() {
+        String className = MessageAbnormalTest.class.getName();
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        topic = getTopic(methodName);
+        try {
+            producer = new DefaultMQProducer("MessageAbnormalTest",rpcHook);
+            producer.setNamesrvAddr(namesrvAddr);
+            producer.start();
+        } catch (MQClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+    }
+
+    @AfterEach
+    public void tearDown() {
+    }
+
+    @AfterAll
+    public static void tearDownAll() {
+
+    }
+
+    //TODO
+    @Disabled
+    @DisplayName("producer invoke send(messageBody=\"\"), expect throw exception")
+    public void sendMsgBodyIsEmpty() {
+        assertThrows(Exception.class, () -> {
+            Message message = MessageFactory.buildMessage(topic, tag, "");
+            producer.send(message);
+        }, "Send messages with a null character message, Expected send() to throw exception, but it didn't");
+    }
+
+    @Test
+    @DisplayName("producer invoke send(messageBody=null), expect build message throw exception")
+    public void sendMsgBodyIsNull() {
+        assertThrows(Exception.class, () -> {
+            Message message = MessageFactory.buildMessage(topic, tag, null);
+            producer.send(message);
+        }, "Send messages with a null character message, Expected build() to throw exception, but it didn't");
+    }
+
+    @Test
+    @DisplayName("producer invoke send(topic=\"\"), expect throw exception")
+    public void sendMsgTopicIsEmpty() {
+        assertThrows(Exception.class, () -> {
+            Message message = MessageFactory.buildMessage("", tag, RandomUtils.getStringByUUID());
+            producer.send(message);
+        }, "Topic does not exist, Expected build() to throw exception, but it didn't");
+    }
+
+    @Test
+    @DisplayName("producer invoke send(topic=null), expect throw exception")
+    public void sendMsgTopicIsNull() {
+        assertThrows(Exception.class, () -> {
+            Message message = MessageFactory.buildMessage(null, tag, RandomUtils.getStringByUUID());
+            producer.send(message);
+        }, "Topic does not exist,Expected build() to throw exception, but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("producer invoke send(tag=null), expect build message throw exception")
+    public void sendMsgTagIsNull() {
+        assertThrows(Exception.class, () -> {
+            Message message = MessageFactory.buildMessage(topic, null, RandomUtils.getStringByUUID());
+            producer.send(message);
+        }, "tag is null, Expected build() to throw exception, but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("producer invoke send(tag=\"\"), expect build message throw exception")
+    public void sendMsgTagIsEmpty() {
+        assertThrows(Exception.class, () -> {
+            Message message = MessageFactory.buildMessage(topic, "", RandomUtils.getStringByUUID());
+            producer.send(message);
+        }, "tag is blank, Expected build() to throw exception, but it didn't");
+    }
+}

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageBodyContentTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageBodyContentTest.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
  * Test message body
  */
 @Tag(TESTSET.CLIENT)
-@Tag(TESTSET.SMOKE)
 public class MessageBodyContentTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(MessageBodyContentTest.class);
     private String tag;
@@ -74,20 +73,16 @@ public class MessageBodyContentTest extends BaseOperate {
         String groupId = getGroupId(methodName);
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
-        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,tag);
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
+        pushConsumer.subscribeAndStart(topic, tag, new RMQNormalListener());
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
         String body = " ";
-        producer.send(topic,tag,body);
+        producer.send(topic, tag, body);
 
         Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
-        VerifyUtils.verifyNormalMessageWithBody(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages(), body);
+        VerifyUtils.verifyNormalMessageWithBody(producer.getEnqueueMessages(),
+                pushConsumer.getListener().getDequeueMessages(), body);
     }
 
     @Test
@@ -97,20 +92,16 @@ public class MessageBodyContentTest extends BaseOperate {
         String groupId = getGroupId(methodName);
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
-        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,tag);
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
+        pushConsumer.subscribeAndStart(topic, tag, new RMQNormalListener());
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
         String body = "中文字符";
-        producer.send(topic,tag,body);
+        producer.send(topic, tag, body);
 
         Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
-        VerifyUtils.verifyNormalMessageWithBody(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages(), body);
+        VerifyUtils.verifyNormalMessageWithBody(producer.getEnqueueMessages(),
+                pushConsumer.getListener().getDequeueMessages(), body);
     }
 
     @Test
@@ -120,21 +111,15 @@ public class MessageBodyContentTest extends BaseOperate {
         String groupId = getGroupId(methodName);
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
-        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,tag);
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
+        pushConsumer.subscribeAndStart(topic, tag, new RMQNormalListener());
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
         String body = "😱";
-        producer.send(topic,tag,body);
+        producer.send(topic, tag, body);
 
         Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
-        VerifyUtils.verifyNormalMessageWithBody(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages(), body);
+        VerifyUtils.verifyNormalMessageWithBody(producer.getEnqueueMessages(),
+                pushConsumer.getListener().getDequeueMessages(), body);
     }
 }
-
-

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageBodyContentTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageBodyContentTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.message;
+
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test message body
+ */
+@Tag(TESTSET.CLIENT)
+@Tag(TESTSET.SMOKE)
+public class MessageBodyContentTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(MessageBodyContentTest.class);
+    private String tag;
+    private static String topic;
+    private RMQNormalProducer producer;
+    private RMQNormalConsumer pushConsumer;
+    private RMQNormalConsumer pullConsumer;
+
+    @BeforeAll
+    public static void setUpAll() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        topic = getTopic(methodName);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (producer != null) {
+            producer.shutdown();
+        }
+        if (pushConsumer != null) {
+            pushConsumer.shutdown();
+        }
+        if (pullConsumer != null) {
+            pullConsumer.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("Send normal message, setting message body with space character, expect consume success")
+    public void testMessageBodyContentIsSpace() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String groupId = getGroupId(methodName);
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,tag);
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        String body = " ";
+        producer.send(topic,tag,body);
+
+        Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessageWithBody(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages(), body);
+    }
+
+    @Test
+    @DisplayName("Send normal message, setting message body with chinese character, expect consume success")
+    public void testMessageBodyContentIsChinese() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String groupId = getGroupId(methodName);
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,tag);
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        String body = "中文字符";
+        producer.send(topic,tag,body);
+
+        Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessageWithBody(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages(), body);
+    }
+
+    @Test
+    @DisplayName("Send normal message, setting message body with emoji(😱) character, expect consume success ")
+    public void testMessageBodyContentIsEmoji() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String groupId = getGroupId(methodName);
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,tag);
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        String body = "😱";
+        producer.send(topic,tag,body);
+
+        Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessageWithBody(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages(), body);
+    }
+}
+
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageKeyTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageKeyTest.java
@@ -83,7 +83,7 @@ public class MessageKeyTest extends BaseOperate {
     }
 
     @Disabled
-    @DisplayName("Message Key equals 16KB, expect send success") // 无意义
+    @DisplayName("Message Key equals 16KB, expect send success")
     public void testMessageKeyEquals16KB() {
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         String body = RandomStringUtils.randomAlphabetic(64);

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageKeyTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageKeyTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.message;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test message key
+ */
+@Tag(TESTSET.CLIENT)
+@Tag(TESTSET.SMOKE)
+public class MessageKeyTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(MessageKeyTest.class);
+    private static String topic;
+    private RMQNormalProducer producer;
+    private RMQNormalConsumer pushConsumer;
+    private RMQNormalConsumer pullConsumer;
+
+    @BeforeAll
+    public static void setUpAll() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        topic = getTopic(methodName);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (producer != null) {
+            producer.shutdown();
+        }
+        if (pushConsumer != null) {
+            pushConsumer.shutdown();
+        }
+        if (pullConsumer != null) {
+            pullConsumer.shutdown();
+        }
+    }
+
+    @Disabled
+    @DisplayName("Message Key beyond 16KB, expect throw exception")
+    public void testMessageKeyBeyond16KB() {
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        String body = RandomStringUtils.randomAlphabetic(64);
+        String key = RandomStringUtils.randomAlphabetic(16 * 1024 + 1);
+
+        Assertions.assertNotNull(producer);
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, "*",key, body.getBytes());
+            producer.getProducer().send(message);
+        }, " message key beyond 16KB , expect throw exception but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("Message Key equals 16KB, expect send success") //无意义
+    public void testMessageKeyEquals16KB() {
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        String body = RandomStringUtils.randomAlphabetic(64);
+        String key = RandomStringUtils.randomAlphabetic(16 * 1024);
+        Assertions.assertNotNull(producer);
+
+        Message message = new Message(topic, "*",key, body.getBytes());
+        producer.send(message);
+    }
+
+    @Disabled
+    @DisplayName("Message Key contains invisible characters \u0000 ,expect throw exception")
+    public void testMessageKeyWithInvisibleCharacter() {
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        String body = RandomStringUtils.randomAlphabetic(64);
+        String key = "\u0000";
+
+        Assertions.assertNotNull(producer);
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, "*",key, body.getBytes());
+            producer.getProducer().send(message);
+        }, " message key contains invisible character ,expect throw exception but it didn't");
+    }
+
+    @Test
+    @DisplayName("Message key contains Chinese, expect send and consume success")
+    public void testMessageKeyContentWithChinese() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String groupId = getGroupId(methodName);
+
+        String key = "中文字符";
+        String tag = NameUtils.getRandomTagName();
+        String body = RandomStringUtils.randomAlphabetic(64);
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,tag);
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer);
+
+        Message message = new Message(topic, tag, key, body.getBytes());
+        producer.send(message);
+
+        Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("The message contains multiple keys, expect send and consume success")
+    public void testMessageWithMultiKey() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String groupId = getGroupId(methodName);
+
+        String key1 = RandomStringUtils.randomAlphabetic(64);
+        String key2 = RandomStringUtils.randomAlphabetic(64);
+        String tag = NameUtils.getRandomTagName();
+        String body = RandomStringUtils.randomAlphabetic(64);
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,tag);
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer);
+
+        Message message = new Message(topic, tag, RandomUtils.getStringByUUID(), body.getBytes());
+        message.setKeys(Arrays.asList(key1,key2));
+        producer.send(message);
+
+        Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+}
+
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageKeyTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageKeyTest.java
@@ -42,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Test message key
  */
 @Tag(TESTSET.CLIENT)
-@Tag(TESTSET.SMOKE)
 public class MessageKeyTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(MessageKeyTest.class);
     private static String topic;
@@ -78,20 +77,20 @@ public class MessageKeyTest extends BaseOperate {
 
         Assertions.assertNotNull(producer);
         assertThrows(Exception.class, () -> {
-            Message message = new Message(topic, "*",key, body.getBytes());
+            Message message = new Message(topic, "*", key, body.getBytes());
             producer.getProducer().send(message);
         }, " message key beyond 16KB , expect throw exception but it didn't");
     }
 
     @Disabled
-    @DisplayName("Message Key equals 16KB, expect send success") //无意义
+    @DisplayName("Message Key equals 16KB, expect send success") // 无意义
     public void testMessageKeyEquals16KB() {
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         String body = RandomStringUtils.randomAlphabetic(64);
         String key = RandomStringUtils.randomAlphabetic(16 * 1024);
         Assertions.assertNotNull(producer);
 
-        Message message = new Message(topic, "*",key, body.getBytes());
+        Message message = new Message(topic, "*", key, body.getBytes());
         producer.send(message);
     }
 
@@ -104,7 +103,7 @@ public class MessageKeyTest extends BaseOperate {
 
         Assertions.assertNotNull(producer);
         assertThrows(Exception.class, () -> {
-            Message message = new Message(topic, "*",key, body.getBytes());
+            Message message = new Message(topic, "*", key, body.getBytes());
             producer.getProducer().send(message);
         }, " message key contains invisible character ,expect throw exception but it didn't");
     }
@@ -120,12 +119,7 @@ public class MessageKeyTest extends BaseOperate {
         String body = RandomStringUtils.randomAlphabetic(64);
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
-        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,tag);
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
+        pushConsumer.subscribeAndStart(topic, tag, new RMQNormalListener());
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer);
@@ -149,23 +143,16 @@ public class MessageKeyTest extends BaseOperate {
         String body = RandomStringUtils.randomAlphabetic(64);
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
-        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,tag);
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
+        pushConsumer.subscribeAndStart(topic, tag, new RMQNormalListener());
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer);
 
         Message message = new Message(topic, tag, RandomUtils.getStringByUUID(), body.getBytes());
-        message.setKeys(Arrays.asList(key1,key2));
+        message.setKeys(Arrays.asList(key1, key2));
         producer.send(message);
 
         Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
         VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
     }
 }
-
-

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageTagTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageTagTest.java
@@ -40,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Test message tag
  */
 @Tag(TESTSET.CLIENT)
-@Tag(TESTSET.SMOKE)
 public class MessageTagTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(MessageTagTest.class);
     private static String topic;
@@ -82,7 +81,7 @@ public class MessageTagTest extends BaseOperate {
     }
 
     @Disabled
-    @DisplayName("Message Tag equals 16KB, expect send success")// 无意义
+    @DisplayName("Message Tag equals 16KB, expect send success") // 无意义
     public void testMessageTagEquals16KB() {
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         String tag = RandomStringUtils.randomAlphabetic(16 * 1024);
@@ -101,7 +100,8 @@ public class MessageTagTest extends BaseOperate {
 
         Assertions.assertNotNull(producer);
         assertThrows(Exception.class, () -> {
-            Message message = new Message(topic, tag,RandomUtils.getStringByUUID(), RandomUtils.getStringByUUID().getBytes(StandardCharsets.UTF_8));
+            Message message = new Message(topic, tag, RandomUtils.getStringByUUID(),
+                    RandomUtils.getStringByUUID().getBytes(StandardCharsets.UTF_8));
             producer.getProducer().send(message);
         }, " message tag contains invisible character ,expect throw exception but it didn't");
     }
@@ -115,7 +115,8 @@ public class MessageTagTest extends BaseOperate {
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
         assertThrows(Exception.class, () -> {
-            Message message = new Message(topic, tag,RandomUtils.getStringByUUID(), body.getBytes(StandardCharsets.UTF_8));
+            Message message = new Message(topic, tag, RandomUtils.getStringByUUID(),
+                    body.getBytes(StandardCharsets.UTF_8));
             producer.getProducer().send(message);
         }, " message tag contains | , expect throw exception but it didn't");
 
@@ -131,22 +132,20 @@ public class MessageTagTest extends BaseOperate {
         String body = RandomStringUtils.randomAlphabetic(64);
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
-        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
+        pushConsumer.subscribeAndStart(topic, tag, new RMQNormalListener());
 
         pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,tag);
+        pullConsumer.subscribeAndStartLitePull(topic, tag);
         VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
         pullConsumer.shutdown();
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer);
 
-        Message message = new Message(topic, tag,RandomUtils.getStringByUUID(), body.getBytes(StandardCharsets.UTF_8));
+        Message message = new Message(topic, tag, RandomUtils.getStringByUUID(), body.getBytes(StandardCharsets.UTF_8));
         producer.send(message);
 
         Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
         VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
     }
 }
-
-

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageTagTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageTagTest.java
@@ -81,7 +81,7 @@ public class MessageTagTest extends BaseOperate {
     }
 
     @Disabled
-    @DisplayName("Message Tag equals 16KB, expect send success") // 无意义
+    @DisplayName("Message Tag equals 16KB, expect send success")
     public void testMessageTagEquals16KB() {
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         String tag = RandomStringUtils.randomAlphabetic(16 * 1024);

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageTagTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageTagTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.message;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test message tag
+ */
+@Tag(TESTSET.CLIENT)
+@Tag(TESTSET.SMOKE)
+public class MessageTagTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(MessageTagTest.class);
+    private static String topic;
+    private RMQNormalProducer producer;
+    private RMQNormalConsumer pushConsumer;
+    private RMQNormalConsumer pullConsumer;
+
+    @BeforeAll
+    public static void setUpAll() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        topic = getTopic(methodName);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (producer != null) {
+            producer.shutdown();
+        }
+        if (pushConsumer != null) {
+            pushConsumer.shutdown();
+        }
+        if (pullConsumer != null) {
+            pullConsumer.shutdown();
+        }
+    }
+
+    @Disabled
+    @DisplayName("Message Tag beyond 16KB, expect throw exception")
+    public void testMessageTagBeyond16KB() {
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        String tag = RandomStringUtils.randomAlphabetic(16 * 1024 + 1);
+        String body = RandomStringUtils.randomAlphabetic(64);
+
+        Assertions.assertNotNull(producer);
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, tag, RandomUtils.getStringByUUID(), body.getBytes());
+            producer.getProducer().send(message);
+        }, " message tag beyond 16KB ,expect throw exception but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("Message Tag equals 16KB, expect send success")// 无意义
+    public void testMessageTagEquals16KB() {
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        String tag = RandomStringUtils.randomAlphabetic(16 * 1024);
+        String body = RandomStringUtils.randomAlphabetic(64);
+
+        Message message = new Message(topic, tag, RandomUtils.getStringByUUID(), body.getBytes());
+        producer.send(message);
+    }
+
+    @Disabled
+    @DisplayName("Message Tag contains invisible characters \u0000 ,expect throw exception")
+    public void testMessageTagWithInvisibleCharacter() {
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        String tag = "\u0000";
+
+        Assertions.assertNotNull(producer);
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, tag,RandomUtils.getStringByUUID(), RandomUtils.getStringByUUID().getBytes(StandardCharsets.UTF_8));
+            producer.getProducer().send(message);
+        }, " message tag contains invisible character ,expect throw exception but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("Message Tag contains | , expect throw exception")
+    public void testMessageTagContentWith() {
+        String tag = "tag|";
+        String body = RandomStringUtils.randomAlphabetic(64);
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, tag,RandomUtils.getStringByUUID(), body.getBytes(StandardCharsets.UTF_8));
+            producer.getProducer().send(message);
+        }, " message tag contains | , expect throw exception but it didn't");
+
+    }
+
+    @Test
+    @DisplayName("Message Tag contains Chinese, expect send and consume success")
+    public void testMessageTagContentWithChinese() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String groupId = getGroupId(methodName);
+
+        String tag = "中文字符";
+        String body = RandomStringUtils.randomAlphabetic(64);
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic,tag, new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,tag);
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer);
+
+        Message message = new Message(topic, tag,RandomUtils.getStringByUUID(), body.getBytes(StandardCharsets.UTF_8));
+        producer.send(message);
+
+        Assertions.assertEquals(1, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+}
+
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageUserPropertyTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageUserPropertyTest.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Test user property
  */
 @Tag(TESTSET.CLIENT)
-@Tag(TESTSET.SMOKE)
 public class MessageUserPropertyTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(MessageUserPropertyTest.class);
     private static String topic;
@@ -58,174 +57,35 @@ public class MessageUserPropertyTest extends BaseOperate {
     }
 
     @Disabled
-    @DisplayName("Message user property beyond limit 128 ,expect throw exception")
-    public void testMessageUserPropertyBeyondSize128() {
-        Map<String, String> userProperty = new HashMap<>();
-        for (int i = 0; i <= 128; i++) {
-            userProperty.put(String.valueOf(i), RandomStringUtils.randomAlphabetic(2));
-        }
-        assertThrows(Exception.class, () -> {
-            Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
-            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
-                message.putUserProperty(entry.getKey(), entry.getValue());
-            }
-            producer.getProducer().send(message);
-        }, " message user property beyond limit 128 ,expect throw exception but it didn't");
-    }
-
-    @Disabled
-    @DisplayName("The number of message user propertys equals limit 128, expect send success") //无意义
-    public void testMessageUserPropertyEqualsSize128() {
-        HashMap<String, String> userProperty = new HashMap<>();
-        for (int i = 0; i < 128; i++) {
-            userProperty.put(String.valueOf(i), RandomStringUtils.randomAlphabetic(2));
-        }
-        Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
-        for(Map.Entry<String, String> entry : userProperty.entrySet()) {
-            message.putUserProperty(entry.getKey(), entry.getValue());
-        }
-        producer.send(message);
-    }
-
-    @Disabled
-    @DisplayName("Message user property equals limit 16KB, expect send success")//无意义
+    @DisplayName("Message user property equals limit 31KB, expect send success")
     public void testMessageUserPropertyEquals16KB() {
-        String key = RandomStringUtils.randomAlphabetic(8 * 1024);
-        String value = RandomStringUtils.randomAlphabetic(8 * 1024);
+        String key = RandomStringUtils.randomAlphabetic(31 * 512);
+        String value = RandomStringUtils.randomAlphabetic(31 * 512);
         HashMap<String, String> userProperty = new HashMap<>();
         userProperty.put(key, value);
 
         Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
-        for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+        for (Map.Entry<String, String> entry : userProperty.entrySet()) {
             message.putUserProperty(entry.getKey(), entry.getValue());
         }
         producer.send(message);
     }
 
     @Disabled
-    @DisplayName("Message user property beyond 16KB ,expect throw exception")
+    @DisplayName("Message user property limit 32KB ,expect throw exception")
     public void testMessageUserPropertyBeyond16KB() {
-        String key = RandomStringUtils.randomAlphabetic(8 * 1024);
-        String value = RandomStringUtils.randomAlphabetic(8 * 1024 + 1);
+        String key = RandomStringUtils.randomAlphabetic(16 * 1024);
+        String value = RandomStringUtils.randomAlphabetic(16 * 1024);
         HashMap<String, String> userProperty = new HashMap<>();
         userProperty.put(key, value);
 
         assertThrows(Exception.class, () -> {
             Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
-            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+            for (Map.Entry<String, String> entry : userProperty.entrySet()) {
                 message.putUserProperty(entry.getKey(), entry.getValue());
             }
             producer.getProducer().send(message);
         }, " message user property beyond 16KB ,expect throw exception but it didn't");
     }
 
-    @Test
-    @DisplayName("Message user property contains invisible character \u0000 ,expect throw exception")
-    public void testMessageUserPropertyContentWithInvisibleCharacter() {
-        HashMap<String, String> userProperty = new HashMap<>();
-        userProperty.put("\u0000", "value");
-
-        assertThrows(Exception.class, () -> {
-            Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
-            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
-                message.putUserProperty(entry.getKey(), entry.getValue());
-            }
-            producer.getProducer().send(message);
-        }, " message user property contains invisible character ,expect throw exception but it didn't");
-
-    }
-
-    @Test
-    @DisplayName("Message user property use SystemKey UNIQ_KEY, expect throw exception")
-    public void testMessageUserPropertyWithSystemKey() {
-        HashMap<String, String> userProperty = new HashMap<>();
-        userProperty.put("UNIQ_KEY", "value");
-
-        assertThrows(Exception.class, () -> {
-            Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
-            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
-                message.putUserProperty(entry.getKey(), entry.getValue());
-            }
-            producer.getProducer().send(message);
-        }, " message user property use system key UNIQ_KEY ,expect throw exception but it didn't");
-
-    }
-
-    @Disabled
-    @DisplayName("Message user property ,key and tag beyond 16KB ,expect throw exception")
-    public void testMessageUserPropertyKeyAndTagBeyond16KB() {
-        HashMap<String, String> userProperty = new HashMap<>();
-        String body = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
-        String key = RandomStringUtils.randomAlphabetic(4 * 1024);
-        String value = RandomStringUtils.randomAlphabetic(4 * 1024);
-        userProperty.put(key, value);
-        String tag = RandomStringUtils.randomAlphabetic(4 * 1024);
-        String msgKey = RandomStringUtils.randomAlphabetic(4 * 1024 + 1);
-
-        assertThrows(Exception.class, () -> {
-            Message message = new Message(topic, tag, msgKey, body.getBytes());
-            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
-                message.putUserProperty(entry.getKey(), entry.getValue());
-            }
-            producer.getProducer().send(message);
-        }, "message user property ,key and tag beyond 16KB ,expect throw exception but it didn't");
-
-    }
-
-    @Test
-    @DisplayName("Message user property ,key and tag equals 16KB, expect send success")
-    public void testMessageUserPropertyKeyAndTagEquals16KB() {
-        HashMap<String, String> userProperty = new HashMap<>();
-        String body = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
-        String key = RandomStringUtils.randomAlphabetic(4 * 1024);
-        String value = RandomStringUtils.randomAlphabetic(4 * 1024);
-        userProperty.put(key, value);
-        String tag = RandomStringUtils.randomAlphabetic(4 * 1024);
-        String msgKey = RandomStringUtils.randomAlphabetic(4 * 1024);
-
-        Message message = new Message(topic, tag, msgKey, body.getBytes());
-        for(Map.Entry<String, String> entry : userProperty.entrySet()) {
-            message.putUserProperty(entry.getKey(), entry.getValue());
-        }
-        producer.send(message);
-    }
-
-    @Test
-    @DisplayName("Message user property ,key and tag equals 64B, expect send success")
-    public void testMessageUserPropertyKeyAndTagEquals64B() {
-        HashMap<String, String> userProperty = new HashMap<>();
-        String body = RandomStringUtils.randomAlphabetic(64);
-        String key = RandomStringUtils.randomAlphabetic(64);
-        String value = RandomStringUtils.randomAlphabetic(64);
-        userProperty.put(key, value);
-        String tag = RandomStringUtils.randomAlphabetic(64);
-        String msgKey = RandomStringUtils.randomAlphabetic(64);
-
-        Message message = new Message(topic, tag, msgKey, body.getBytes());
-        for(Map.Entry<String, String> entry : userProperty.entrySet()) {
-            message.putUserProperty(entry.getKey(), entry.getValue());
-        }
-        producer.send(message);
-
-    }
-
-    @Test
-    @DisplayName("Message user property is the visible character, expect send success")
-    public void testSpecialCharProperty() {
-        HashMap<String, String> userProps = new HashMap<>();
-        userProps.put("中文", "中文");
-        userProps.put("_", "_");
-        userProps.put("%", "%");
-        userProps.put("。", "。");
-        userProps.put("||", "||");
-        userProps.put("&&", "&&");
-        userProps.put("🏷", "🏷");
-        Message message = new Message(topic,RandomUtils.getStringByUUID().getBytes());
-        for(Map.Entry<String, String> entry : userProps.entrySet()) {
-            message.putUserProperty(entry.getKey(), entry.getValue());
-        }
-        producer.send(message);
-    }
 }
-
-

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageUserPropertyTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/MessageUserPropertyTest.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.message;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test user property
+ */
+@Tag(TESTSET.CLIENT)
+@Tag(TESTSET.SMOKE)
+public class MessageUserPropertyTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(MessageUserPropertyTest.class);
+    private static String topic;
+    private static RMQNormalProducer producer;
+
+    @BeforeAll
+    public static void setUpAll() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        topic = getTopic(methodName);
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+    }
+
+    @AfterAll
+    public static void tearDownAll() {
+        if (producer != null) {
+            producer.shutdown();
+        }
+    }
+
+    @Disabled
+    @DisplayName("Message user property beyond limit 128 ,expect throw exception")
+    public void testMessageUserPropertyBeyondSize128() {
+        Map<String, String> userProperty = new HashMap<>();
+        for (int i = 0; i <= 128; i++) {
+            userProperty.put(String.valueOf(i), RandomStringUtils.randomAlphabetic(2));
+        }
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
+            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+                message.putUserProperty(entry.getKey(), entry.getValue());
+            }
+            producer.getProducer().send(message);
+        }, " message user property beyond limit 128 ,expect throw exception but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("The number of message user propertys equals limit 128, expect send success") //无意义
+    public void testMessageUserPropertyEqualsSize128() {
+        HashMap<String, String> userProperty = new HashMap<>();
+        for (int i = 0; i < 128; i++) {
+            userProperty.put(String.valueOf(i), RandomStringUtils.randomAlphabetic(2));
+        }
+        Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
+        for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+            message.putUserProperty(entry.getKey(), entry.getValue());
+        }
+        producer.send(message);
+    }
+
+    @Disabled
+    @DisplayName("Message user property equals limit 16KB, expect send success")//无意义
+    public void testMessageUserPropertyEquals16KB() {
+        String key = RandomStringUtils.randomAlphabetic(8 * 1024);
+        String value = RandomStringUtils.randomAlphabetic(8 * 1024);
+        HashMap<String, String> userProperty = new HashMap<>();
+        userProperty.put(key, value);
+
+        Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
+        for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+            message.putUserProperty(entry.getKey(), entry.getValue());
+        }
+        producer.send(message);
+    }
+
+    @Disabled
+    @DisplayName("Message user property beyond 16KB ,expect throw exception")
+    public void testMessageUserPropertyBeyond16KB() {
+        String key = RandomStringUtils.randomAlphabetic(8 * 1024);
+        String value = RandomStringUtils.randomAlphabetic(8 * 1024 + 1);
+        HashMap<String, String> userProperty = new HashMap<>();
+        userProperty.put(key, value);
+
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
+            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+                message.putUserProperty(entry.getKey(), entry.getValue());
+            }
+            producer.getProducer().send(message);
+        }, " message user property beyond 16KB ,expect throw exception but it didn't");
+    }
+
+    @Test
+    @DisplayName("Message user property contains invisible character \u0000 ,expect throw exception")
+    public void testMessageUserPropertyContentWithInvisibleCharacter() {
+        HashMap<String, String> userProperty = new HashMap<>();
+        userProperty.put("\u0000", "value");
+
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
+            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+                message.putUserProperty(entry.getKey(), entry.getValue());
+            }
+            producer.getProducer().send(message);
+        }, " message user property contains invisible character ,expect throw exception but it didn't");
+
+    }
+
+    @Test
+    @DisplayName("Message user property use SystemKey UNIQ_KEY, expect throw exception")
+    public void testMessageUserPropertyWithSystemKey() {
+        HashMap<String, String> userProperty = new HashMap<>();
+        userProperty.put("UNIQ_KEY", "value");
+
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, RandomUtils.getStringByUUID().getBytes());
+            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+                message.putUserProperty(entry.getKey(), entry.getValue());
+            }
+            producer.getProducer().send(message);
+        }, " message user property use system key UNIQ_KEY ,expect throw exception but it didn't");
+
+    }
+
+    @Disabled
+    @DisplayName("Message user property ,key and tag beyond 16KB ,expect throw exception")
+    public void testMessageUserPropertyKeyAndTagBeyond16KB() {
+        HashMap<String, String> userProperty = new HashMap<>();
+        String body = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
+        String key = RandomStringUtils.randomAlphabetic(4 * 1024);
+        String value = RandomStringUtils.randomAlphabetic(4 * 1024);
+        userProperty.put(key, value);
+        String tag = RandomStringUtils.randomAlphabetic(4 * 1024);
+        String msgKey = RandomStringUtils.randomAlphabetic(4 * 1024 + 1);
+
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(topic, tag, msgKey, body.getBytes());
+            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+                message.putUserProperty(entry.getKey(), entry.getValue());
+            }
+            producer.getProducer().send(message);
+        }, "message user property ,key and tag beyond 16KB ,expect throw exception but it didn't");
+
+    }
+
+    @Test
+    @DisplayName("Message user property ,key and tag equals 16KB, expect send success")
+    public void testMessageUserPropertyKeyAndTagEquals16KB() {
+        HashMap<String, String> userProperty = new HashMap<>();
+        String body = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
+        String key = RandomStringUtils.randomAlphabetic(4 * 1024);
+        String value = RandomStringUtils.randomAlphabetic(4 * 1024);
+        userProperty.put(key, value);
+        String tag = RandomStringUtils.randomAlphabetic(4 * 1024);
+        String msgKey = RandomStringUtils.randomAlphabetic(4 * 1024);
+
+        Message message = new Message(topic, tag, msgKey, body.getBytes());
+        for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+            message.putUserProperty(entry.getKey(), entry.getValue());
+        }
+        producer.send(message);
+    }
+
+    @Test
+    @DisplayName("Message user property ,key and tag equals 64B, expect send success")
+    public void testMessageUserPropertyKeyAndTagEquals64B() {
+        HashMap<String, String> userProperty = new HashMap<>();
+        String body = RandomStringUtils.randomAlphabetic(64);
+        String key = RandomStringUtils.randomAlphabetic(64);
+        String value = RandomStringUtils.randomAlphabetic(64);
+        userProperty.put(key, value);
+        String tag = RandomStringUtils.randomAlphabetic(64);
+        String msgKey = RandomStringUtils.randomAlphabetic(64);
+
+        Message message = new Message(topic, tag, msgKey, body.getBytes());
+        for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+            message.putUserProperty(entry.getKey(), entry.getValue());
+        }
+        producer.send(message);
+
+    }
+
+    @Test
+    @DisplayName("Message user property is the visible character, expect send success")
+    public void testSpecialCharProperty() {
+        HashMap<String, String> userProps = new HashMap<>();
+        userProps.put("中文", "中文");
+        userProps.put("_", "_");
+        userProps.put("%", "%");
+        userProps.put("。", "。");
+        userProps.put("||", "||");
+        userProps.put("&&", "&&");
+        userProps.put("🏷", "🏷");
+        Message message = new Message(topic,RandomUtils.getStringByUUID().getBytes());
+        for(Map.Entry<String, String> entry : userProps.entrySet()) {
+            message.putUserProperty(entry.getKey(), entry.getValue());
+        }
+        producer.send(message);
+    }
+}
+
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/NormalMessageSizeTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/NormalMessageSizeTest.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.message;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.LocalTransactionState;
+import org.apache.rocketmq.client.producer.TransactionMQProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.TransactionListenerImpl;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag(TESTSET.NORMAL)
+@Tag(TESTSET.SMOKE)
+@DisplayName("Test cases that send messages")
+public class NormalMessageSizeTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(NormalMessageSizeTest.class);
+    private static String normalTopic;
+    private static String transTopic;
+    private static String fifoTopic;
+    private static String delayTopic;
+    private static DefaultMQProducer producer;
+
+    @BeforeAll
+    public static void setUpAll() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        normalTopic = getTopic(methodName);
+        transTopic = getTopic(methodName);
+        delayTopic = getTopic(methodName);
+        fifoTopic = getTopic(methodName);
+    }
+
+    @AfterAll
+    public static void tearDownAll() {
+        if (producer != null) {
+            producer.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("Send normal messages synchronously with the body size of 4M+1, expect send failed")
+    public void testNormalMsgSize4MAdd1() {
+        producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        try {
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start DefaultMQProducer failed, {}", e.getMessage());
+        }
+
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024 + 1);
+        String tag = NameUtils.getRandomTagName();
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(normalTopic,tag,messageBody.getBytes());
+            producer.send(message);
+        });
+    }
+
+    @Test
+    @DisplayName("Send normal messages synchronously with the body size of 4M, expect send success")
+    public void testNormalMsgSize4M() {
+        producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        try {
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start DefaultMQProducer failed, {}", e.getMessage());
+        }
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
+        String tag = NameUtils.getRandomTagName();
+        Message message = new Message(normalTopic,tag,messageBody.getBytes());
+        try {
+            producer.send(message);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail("Send message failed, expected success");
+        }
+    }
+
+    @Test
+    @DisplayName("Send delay messages synchronously with the body size of 4M+1, expect send failed")
+    public void testDelayMsgSize4MAdd1() {
+        producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        try {
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start DefaultMQProducer failed, {}", e.getMessage());
+        }
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024 + 1);
+        String tag = NameUtils.getRandomTagName();
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(delayTopic, tag,messageBody.getBytes());
+            message.setDelayTimeLevel(3);
+            producer.send(message);
+        });
+    }
+
+    @Test
+    @DisplayName("Send delay messages synchronously with the body size of 4M, expect send success")
+    public void testDelayMsgSize4M() {
+        producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        try {
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start DefaultMQProducer failed, {}", e.getMessage());
+        }
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
+        String tag = NameUtils.getRandomTagName();
+        Message message = new Message(delayTopic, tag,messageBody.getBytes());
+        message.setDelayTimeLevel(3);
+        try {
+            producer.send(message);
+        } catch (MQClientException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (MQBrokerException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (RemotingException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (InterruptedException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("Send transaction messages synchronously with the body size of 4M+1, expect send failed")
+    public void testTransMsgSize4MAdd1() {
+        TransactionMQProducer producer = new TransactionMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        TransactionListenerImpl transactionListener = new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.COMMIT_MESSAGE);
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName("client-transaction-msg-check-thread");
+                return thread;
+            }
+        });
+        try {
+            if (executorService != null) {
+                producer.setExecutorService(executorService);
+            }
+            producer.setTransactionListener(transactionListener);
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start TransactionMQProducer failed, {}", e.getMessage());
+        }
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024 + 1);
+        String tag = NameUtils.getRandomTagName();
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(transTopic, tag, messageBody.getBytes());
+            producer.sendMessageInTransaction(message, null);
+        });
+        producer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Send transaction messages synchronously with the body size of 4M, expect send success")
+    public void testTransMsgSize4M() {
+        TransactionMQProducer producer = new TransactionMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        TransactionListenerImpl transactionListener = new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.COMMIT_MESSAGE);
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName("client-transaction-msg-check-thread");
+                return thread;
+            }
+        });
+        try {
+            if (executorService != null) {
+                producer.setExecutorService(executorService);
+            }
+            producer.setTransactionListener(transactionListener);
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start TransactionMQProducer failed, {}", e.getMessage());
+        }
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
+        String tag = NameUtils.getRandomTagName();
+        Message message = new Message(transTopic, tag, messageBody.getBytes());
+        try {
+            producer.sendMessageInTransaction(message, null);
+        } catch (MQClientException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        }
+        producer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Send FIFO messages synchronously with the body size of 4M+1, expect send failed")
+    public void testFifoMsgSize4MAdd1() {
+        producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        try {
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start DefaultMQProducer failed, {}", e.getMessage());
+        }
+        List<MessageQueue> messageQueues = null;
+        try {
+            messageQueues = producer.fetchPublishMessageQueues(fifoTopic);
+        } catch (MQClientException e) {
+            Assertions.assertNotNull(messageQueues);
+        }
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024 + 1);
+        String tag = NameUtils.getRandomTagName();
+        List<MessageQueue> finalMessageQueues = messageQueues;
+        assertThrows(Exception.class, () -> {
+            Message message = new Message(fifoTopic, tag, messageBody.getBytes());
+            if(finalMessageQueues.size()>0){
+                producer.send(message, finalMessageQueues.get(0));
+            }
+            producer.send(message);
+        });
+    }
+
+    @Test
+    @DisplayName("Send FIFO messages synchronously with the body size of 4M, expect send success")
+    public void testFifoMsgSize4M() {
+        producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        try {
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start DefaultMQProducer failed, {}", e.getMessage());
+        }
+        List<MessageQueue> messageQueues = null;
+        try {
+            messageQueues = producer.fetchPublishMessageQueues(fifoTopic);
+        } catch (MQClientException e) {
+            Assertions.assertNotNull(messageQueues);
+        }
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
+        String tag = NameUtils.getRandomTagName();
+        Message message = new Message(fifoTopic, tag, messageBody.getBytes());
+        List<MessageQueue> finalMessageQueues = messageQueues;
+        try {
+            if(finalMessageQueues.size()>0){
+                producer.send(message, finalMessageQueues.get(0));
+            }
+        } catch (MQBrokerException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (RemotingException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (InterruptedException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (MQClientException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("Send normal messages synchronously with the body size of 4M and the user property size of 16KB, expect send success")
+    public void testNormalMsgSize4MAndUserProperty16KB() {
+        producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        try {
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start DefaultMQProducer failed, {}", e.getMessage());
+        }
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
+        String key = RandomStringUtils.randomAlphabetic(8 * 1024);
+        String value = RandomStringUtils.randomAlphabetic(8 * 1024);
+        HashMap<String, String> userProperty = new HashMap<>();
+        userProperty.put(key, value);
+        try {
+            Message message = new Message(normalTopic, messageBody.getBytes());
+            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+                message.putUserProperty(entry.getKey(), entry.getValue());
+            }
+            producer.send(message);
+        } catch (MQBrokerException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (RemotingException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (InterruptedException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (MQClientException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("Send FIFO messages synchronously with the body size of 4M and the user property size of 16KB, expect send success")
+    public void testFifoMsgSize4MAndUserProperty16KB() {
+        producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+        producer.setInstanceName(UUID.randomUUID().toString());
+        producer.setNamesrvAddr(namesrvAddr);
+        try {
+            producer.start();
+        } catch (MQClientException e) {
+            log.info("Start DefaultMQProducer failed, {}", e.getMessage());
+        }
+        List<MessageQueue> messageQueues = null;
+        try {
+            messageQueues = producer.fetchPublishMessageQueues(fifoTopic);
+        } catch (MQClientException e) {
+            Assertions.assertNotNull(messageQueues);
+        }
+        String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
+        String key = RandomStringUtils.randomAlphabetic(8 * 1024);
+        String value = RandomStringUtils.randomAlphabetic(8 * 1024);
+        HashMap<String, String> userProperty = new HashMap<>();
+        userProperty.put(key, value);
+        List<MessageQueue> finalMessageQueues = messageQueues;
+        try {
+            Message message = new Message(fifoTopic, messageBody.getBytes());
+            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+                message.putUserProperty(entry.getKey(), entry.getValue());
+            }
+            if(finalMessageQueues.size()>0){
+                producer.send(message, finalMessageQueues.get(0));
+            }
+        } catch (MQBrokerException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (RemotingException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (InterruptedException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        } catch (MQClientException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        }
+    }
+
+}

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/NormalMessageSizeTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/message/NormalMessageSizeTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(TESTSET.NORMAL)
-@Tag(TESTSET.SMOKE)
 @DisplayName("Test cases that send messages")
 public class NormalMessageSizeTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(NormalMessageSizeTest.class);
@@ -87,7 +86,7 @@ public class NormalMessageSizeTest extends BaseOperate {
         String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024 + 1);
         String tag = NameUtils.getRandomTagName();
         assertThrows(Exception.class, () -> {
-            Message message = new Message(normalTopic,tag,messageBody.getBytes());
+            Message message = new Message(normalTopic, tag, messageBody.getBytes());
             producer.send(message);
         });
     }
@@ -105,7 +104,7 @@ public class NormalMessageSizeTest extends BaseOperate {
         }
         String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
         String tag = NameUtils.getRandomTagName();
-        Message message = new Message(normalTopic,tag,messageBody.getBytes());
+        Message message = new Message(normalTopic, tag, messageBody.getBytes());
         try {
             producer.send(message);
         } catch (Exception e) {
@@ -128,7 +127,7 @@ public class NormalMessageSizeTest extends BaseOperate {
         String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024 + 1);
         String tag = NameUtils.getRandomTagName();
         assertThrows(Exception.class, () -> {
-            Message message = new Message(delayTopic, tag,messageBody.getBytes());
+            Message message = new Message(delayTopic, tag, messageBody.getBytes());
             message.setDelayTimeLevel(3);
             producer.send(message);
         });
@@ -147,7 +146,7 @@ public class NormalMessageSizeTest extends BaseOperate {
         }
         String messageBody = RandomStringUtils.randomAlphabetic(4 * 1024 * 1024);
         String tag = NameUtils.getRandomTagName();
-        Message message = new Message(delayTopic, tag,messageBody.getBytes());
+        Message message = new Message(delayTopic, tag, messageBody.getBytes());
         message.setDelayTimeLevel(3);
         try {
             producer.send(message);
@@ -168,15 +167,17 @@ public class NormalMessageSizeTest extends BaseOperate {
         TransactionMQProducer producer = new TransactionMQProducer(RandomUtils.getStringByUUID(), rpcHook);
         producer.setInstanceName(UUID.randomUUID().toString());
         producer.setNamesrvAddr(namesrvAddr);
-        TransactionListenerImpl transactionListener = new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.COMMIT_MESSAGE);
-        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread thread = new Thread(r);
-                thread.setName("client-transaction-msg-check-thread");
-                return thread;
-            }
-        });
+        TransactionListenerImpl transactionListener = new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE,
+                LocalTransactionState.COMMIT_MESSAGE);
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        thread.setName("client-transaction-msg-check-thread");
+                        return thread;
+                    }
+                });
         try {
             if (executorService != null) {
                 producer.setExecutorService(executorService);
@@ -201,15 +202,17 @@ public class NormalMessageSizeTest extends BaseOperate {
         TransactionMQProducer producer = new TransactionMQProducer(RandomUtils.getStringByUUID(), rpcHook);
         producer.setInstanceName(UUID.randomUUID().toString());
         producer.setNamesrvAddr(namesrvAddr);
-        TransactionListenerImpl transactionListener = new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.COMMIT_MESSAGE);
-        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread thread = new Thread(r);
-                thread.setName("client-transaction-msg-check-thread");
-                return thread;
-            }
-        });
+        TransactionListenerImpl transactionListener = new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE,
+                LocalTransactionState.COMMIT_MESSAGE);
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        thread.setName("client-transaction-msg-check-thread");
+                        return thread;
+                    }
+                });
         try {
             if (executorService != null) {
                 producer.setExecutorService(executorService);
@@ -252,7 +255,7 @@ public class NormalMessageSizeTest extends BaseOperate {
         List<MessageQueue> finalMessageQueues = messageQueues;
         assertThrows(Exception.class, () -> {
             Message message = new Message(fifoTopic, tag, messageBody.getBytes());
-            if(finalMessageQueues.size()>0){
+            if (finalMessageQueues.size() > 0) {
                 producer.send(message, finalMessageQueues.get(0));
             }
             producer.send(message);
@@ -281,7 +284,7 @@ public class NormalMessageSizeTest extends BaseOperate {
         Message message = new Message(fifoTopic, tag, messageBody.getBytes());
         List<MessageQueue> finalMessageQueues = messageQueues;
         try {
-            if(finalMessageQueues.size()>0){
+            if (finalMessageQueues.size() > 0) {
                 producer.send(message, finalMessageQueues.get(0));
             }
         } catch (MQBrokerException e) {
@@ -313,7 +316,7 @@ public class NormalMessageSizeTest extends BaseOperate {
         userProperty.put(key, value);
         try {
             Message message = new Message(normalTopic, messageBody.getBytes());
-            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+            for (Map.Entry<String, String> entry : userProperty.entrySet()) {
                 message.putUserProperty(entry.getKey(), entry.getValue());
             }
             producer.send(message);
@@ -353,10 +356,10 @@ public class NormalMessageSizeTest extends BaseOperate {
         List<MessageQueue> finalMessageQueues = messageQueues;
         try {
             Message message = new Message(fifoTopic, messageBody.getBytes());
-            for(Map.Entry<String, String> entry : userProperty.entrySet()) {
+            for (Map.Entry<String, String> entry : userProperty.entrySet()) {
                 message.putUserProperty(entry.getKey(), entry.getValue());
             }
-            if(finalMessageQueues.size()>0){
+            if (finalMessageQueues.size() > 0) {
                 producer.send(message, finalMessageQueues.get(0));
             }
         } catch (MQBrokerException e) {

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/producer/ProducerInitTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/producer/ProducerInitTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.producer;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.AclClient;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@Tag(TESTSET.CLIENT)
+@Tag(TESTSET.SMOKE)
+public class ProducerInitTest extends BaseOperate {
+    private static final Logger log = LoggerFactory.getLogger(ProducerInitTest.class);
+    private static String topic;
+
+    @BeforeAll
+    public static void setUpAll() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        topic = getTopic(methodName);
+    }
+
+    @BeforeEach
+    public void setUp() {
+    }
+
+    @AfterEach
+    public void tearDown() {
+    }
+
+    @Test
+    @DisplayName("Producer is normally set,expected success")
+    public void testNormalSetting() {
+        try {
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+            producer.setNamesrvAddr(namesrvAddr);
+            producer.setInstanceName(UUID.randomUUID().toString());
+            producer.start();
+            producer.shutdown();
+        } catch (MQClientException e) {
+            Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
+        }
+    }
+
+
+    @Disabled
+    @DisplayName("The NAMESRV_ADDR setting of the Producer failed, expect ONSClientException to throw")
+    public void testErrorNameSrvAddr() {
+        assertThrows(Exception.class, () -> {
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
+            producer.setNamesrvAddr("https://www.aliyun.com");
+            producer.setInstanceName(UUID.randomUUID().toString());
+            producer.start();
+            producer.shutdown();
+        }, "Expected ClientException to throw, but it didn't");
+    }
+
+    @Test
+    @DisplayName("The Producer does not set the AccessKey, expect an exception occurs when the client start")
+    public void testUnsetAK() {
+        assertThrows(Exception.class, () -> {
+            RPCHook aclRPCHook = AclClient.getAclRPCHook(null, account.getSecretKey());
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), aclRPCHook);
+            producer.setNamesrvAddr(namesrvAddr);
+            producer.setInstanceName(UUID.randomUUID().toString());
+            producer.start();
+            producer.shutdown();
+        }, "Expected ClientException to throw, but it didn't");
+    }
+
+    @Test
+    @DisplayName("The Producer does not set the SecretKey, expect an exception occurs when the client start")
+    public void testUnsetSK() {
+        assertThrows(Exception.class, () -> {
+            RPCHook aclRPCHook = AclClient.getAclRPCHook(account.getAccessKey(), "");
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), aclRPCHook);
+            producer.setNamesrvAddr(namesrvAddr);
+            producer.setInstanceName(UUID.randomUUID().toString());
+            producer.start();
+            producer.shutdown();
+        }, "Expected ClientException to throw, but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("The Producer does not set the Properties, expect an exception occurs when the client start")
+    public void testUnsetProperties() {
+        assertThrows(Exception.class, () -> {
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(),(RPCHook) null);
+            producer.setNamesrvAddr(namesrvAddr);
+            producer.setInstanceName(UUID.randomUUID().toString());
+            producer.start();
+            producer.shutdown();
+        }, "Expected ClientException to throw, but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("The Producer sets the maximum retry times to 0, expect the client start success")
+    public void testSet0MaxAttempts() {
+        assertThrows(Exception.class, () -> {
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(),rpcHook);
+            producer.setNamesrvAddr(namesrvAddr);
+            producer.setInstanceName(UUID.randomUUID().toString());
+            producer.setRetryTimesWhenSendFailed(0);
+            producer.start();
+            producer.shutdown();
+        }, "Expected ClientException to throw, but it didn't");
+    }
+
+    @Disabled
+    @DisplayName("The Producer sets the maximum retry times to -1, expect the client start failed")
+    public void testSetLess0MaxAttempts() {
+        assertThrows(Exception.class, () -> {
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(),rpcHook);
+            producer.setNamesrvAddr(namesrvAddr);
+            producer.setInstanceName(UUID.randomUUID().toString());
+            producer.setRetryTimesWhenSendFailed(-1);
+            producer.start();
+            producer.shutdown();
+        }, "Expected ClientException to throw, but it didn't");
+    }
+}

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/client/producer/ProducerInitTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/client/producer/ProducerInitTest.java
@@ -31,9 +31,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
 @Tag(TESTSET.CLIENT)
-@Tag(TESTSET.SMOKE)
 public class ProducerInitTest extends BaseOperate {
     private static final Logger log = LoggerFactory.getLogger(ProducerInitTest.class);
     private static String topic;
@@ -65,7 +63,6 @@ public class ProducerInitTest extends BaseOperate {
             Assertions.fail("Send message failed, expected success, message:" + e.getMessage());
         }
     }
-
 
     @Disabled
     @DisplayName("The NAMESRV_ADDR setting of the Producer failed, expect ONSClientException to throw")
@@ -109,7 +106,7 @@ public class ProducerInitTest extends BaseOperate {
     @DisplayName("The Producer does not set the Properties, expect an exception occurs when the client start")
     public void testUnsetProperties() {
         assertThrows(Exception.class, () -> {
-            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(),(RPCHook) null);
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), (RPCHook) null);
             producer.setNamesrvAddr(namesrvAddr);
             producer.setInstanceName(UUID.randomUUID().toString());
             producer.start();
@@ -117,24 +114,26 @@ public class ProducerInitTest extends BaseOperate {
         }, "Expected ClientException to throw, but it didn't");
     }
 
-    @Disabled
+    @Test
     @DisplayName("The Producer sets the maximum retry times to 0, expect the client start success")
     public void testSet0MaxAttempts() {
-        assertThrows(Exception.class, () -> {
-            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(),rpcHook);
+        try {
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
             producer.setNamesrvAddr(namesrvAddr);
             producer.setInstanceName(UUID.randomUUID().toString());
             producer.setRetryTimesWhenSendFailed(0);
             producer.start();
             producer.shutdown();
-        }, "Expected ClientException to throw, but it didn't");
+        } catch (Exception e) {
+            Assertions.fail("Expected the client to start successfully, but it didn't");
+        }
     }
 
     @Disabled
     @DisplayName("The Producer sets the maximum retry times to -1, expect the client start failed")
     public void testSetLess0MaxAttempts() {
         assertThrows(Exception.class, () -> {
-            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(),rpcHook);
+            DefaultMQProducer producer = new DefaultMQProducer(RandomUtils.getStringByUUID(), rpcHook);
             producer.setNamesrvAddr(namesrvAddr);
             producer.setInstanceName(UUID.randomUUID().toString());
             producer.setRetryTimesWhenSendFailed(-1);

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/cluster/ClusterTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/cluster/ClusterTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.cluster;
+
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag(TESTSET.MODEL)
+@Tag(TESTSET.SMOKE)
+public class ClusterTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(ClusterTest.class);
+    private String tag;
+    private final static int SEND_NUM = 100;
+    private RMQNormalConsumer pushConsumer01;
+    private RMQNormalConsumer pushConsumer02;
+    private RMQNormalConsumer pushConsumer03;
+    private RMQNormalConsumer pullConsumer;
+    private RMQNormalProducer producer;
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+    }
+
+    @BeforeEach
+    public void tearDown() {
+        if (pushConsumer01 != null) {
+            pushConsumer01.shutdown();
+        }
+        if (pushConsumer02 != null) {
+            pushConsumer02.shutdown();
+        }
+        if (pushConsumer03 != null) {
+            pushConsumer03.shutdown();
+        }
+        if (pullConsumer != null) {
+            pullConsumer.shutdown();
+        }
+        if (producer != null) {
+            producer.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("Send 100 normal messages synchronously, start three consumers on different GroupId, and expect each client to consume up to 100 messages")
+    public void testBroadcastConsume() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId01 = getGroupId(methodName + 1);
+        String groupId02 = getGroupId(methodName + 2);
+        String groupId03 = getGroupId(methodName + 3);
+
+        RMQNormalListener listenerA = new RMQNormalListener("ListenerA");
+        RMQNormalListener listenerB = new RMQNormalListener("ListenerB");
+        RMQNormalListener listenerC = new RMQNormalListener("ListenerC");
+        pushConsumer01 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId01, rpcHook);
+        pushConsumer02 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId02, rpcHook);
+        pushConsumer03 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId03, rpcHook);
+        pushConsumer01.subscribeAndStart(topic,tag, listenerA);
+        pushConsumer02.subscribeAndStart(topic,tag, listenerB);
+        pushConsumer03.subscribeAndStart(topic,tag, listenerC);
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId01, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,tag);
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get Producer failed");
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = new Message(topic, tag, RandomUtils.getStringByUUID().getBytes());
+            producer.send(message);
+        }
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), listenerA.getDequeueMessages());
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), listenerB.getDequeueMessages());
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), listenerC.getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("Send 100 normal messages synchronously, start 3 consumers on the same GroupId, expect 3 clients to consume a total of 100 messages")
+    public void testClusterConsume() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalListener listenerA = new RMQNormalListener("ListenerA");
+        RMQNormalListener listenerB = new RMQNormalListener("ListenerB");
+        RMQNormalListener listenerC = new RMQNormalListener("ListenerC");
+        pushConsumer01 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer02 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer03 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer01.subscribeAndStart(topic,tag, listenerA);
+        pushConsumer02.subscribeAndStart(topic,tag, listenerB);
+        pushConsumer03.subscribeAndStart(topic,tag, listenerC);
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,tag);
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = new Message(topic, tag, String.valueOf(i).getBytes());
+            producer.send(message);
+        }
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyClusterConsume(producer.getEnqueueMessages(), listenerA.getDequeueMessages(), listenerB.getDequeueMessages(), listenerC.getDequeueMessages());
+    }
+}
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/cluster/LoadBalancingTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/cluster/LoadBalancingTest.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.cluster;
+
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQIdempotentListener;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQOrderListener;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.apache.rocketmq.client.consumer.MessageSelector;
+import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
+import org.apache.rocketmq.client.producer.MessageQueueSelector;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag(TESTSET.LOAD_BALANCING)
+@Tag(TESTSET.SMOKE)
+public class LoadBalancingTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(LoadBalancingTest.class);
+    private String tag;
+    private final static int SEND_NUM = 10;
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+    }
+
+    @Test
+    @DisplayName("Normal message load balancing, start 4 consumers, send 240 messages, expect 4 consumers to consume load balancing, each consume 1/4, then shutdown 2 of them, send 240 messages again, still load balancing, each consume half, and start 2 new consumers. Another 240 messages are sent, still load balanced, each consuming 1/4")
+    public void testLoadBalancing_normal_message() {
+        int messageSize = 240;
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        RMQNormalConsumer consumer1 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer2 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer3 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer4 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        consumer1.subscribeAndStart(topic, tag, new RMQIdempotentListener());
+        consumer2.subscribeAndStart(topic, tag, new RMQIdempotentListener());
+        consumer3.subscribeAndStart(topic, tag, new RMQIdempotentListener());
+        consumer4.subscribeAndStart(topic, tag, new RMQIdempotentListener());
+
+        Assertions.assertNotNull(producer);
+        producer.send(topic, tag, messageSize);
+
+        Assertions.assertEquals(messageSize, producer.getEnqueueMessages().getDataSize(), "send message failed");
+
+        await().atMost(120, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return consumer1.getListener().getDequeueMessages().getDataSize() +
+                       consumer2.getListener().getDequeueMessages().getDataSize() +
+                       consumer3.getListener().getDequeueMessages().getDataSize() +
+                       consumer4.getListener().getDequeueMessages().getDataSize() == messageSize;
+            }
+        });
+
+        Assertions.assertTrue(messageSize/4==consumer1.getListener().getDequeueMessages().getDataSize(), "consumer1: first load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/4==consumer2.getListener().getDequeueMessages().getDataSize(), "consumer2: first load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/4==consumer3.getListener().getDequeueMessages().getDataSize(), "consumer3: first load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/4==consumer4.getListener().getDequeueMessages().getDataSize(), "consumer4: first load balancing is not satisfied");
+
+        consumer1.getListener().clearMsg();
+        consumer2.getListener().clearMsg();
+
+        consumer3.shutdown();
+        consumer4.shutdown();
+
+        producer.send(topic, tag, messageSize);
+
+        await().atMost(120, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return consumer1.getListener().getDequeueMessages().getDataSize() +
+                       consumer2.getListener().getDequeueMessages().getDataSize() == messageSize;
+            }
+        });
+
+        Assertions.assertTrue(messageSize/2==consumer1.getListener().getDequeueMessages().getDataSize(), "consumer1: second load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/2==consumer2.getListener().getDequeueMessages().getDataSize(), "consumer2: second load balancing is not satisfied");
+
+        consumer1.getListener().clearMsg();
+        consumer2.getListener().clearMsg();
+
+        RMQNormalConsumer consumer5 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer6 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        consumer5.subscribeAndStart(topic, tag, new RMQIdempotentListener());
+        consumer6.subscribeAndStart(topic, tag, new RMQIdempotentListener());
+
+        producer.send(topic, tag, messageSize);
+
+        await().atMost(120, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return consumer1.getListener().getDequeueMessages().getDataSize() +
+                       consumer2.getListener().getDequeueMessages().getDataSize() +
+                       consumer5.getListener().getDequeueMessages().getDataSize() +
+                       consumer6.getListener().getDequeueMessages().getDataSize() == messageSize;
+            }
+        });
+
+        Assertions.assertTrue(messageSize/4==consumer1.getListener().getDequeueMessages().getDataSize(), "consumer1: third load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/4==consumer2.getListener().getDequeueMessages().getDataSize(), "consumer2: third load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/4==consumer5.getListener().getDequeueMessages().getDataSize(), "consumer5: third load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/4==consumer6.getListener().getDequeueMessages().getDataSize(), "consumer6: third load balancing is not satisfied");
+
+        producer.shutdown();
+        consumer1.shutdown();
+        consumer2.shutdown();
+        consumer5.shutdown();
+        consumer6.shutdown();
+    }
+
+    @Test
+    @DisplayName("Global sequential message load balancing: Start 2 consumers, send 30 messages, expect only 1 Consumer to consume the message, and the other Consumer to consume 0, then shutdown 1 Consumer with message consumption, send another 30 messages, expect the idling Consumer to pull the message")
+    public void testLoadBalancing_global_sequential_message(){
+        int messageSize = 30;
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        RMQNormalConsumer consumer1 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer2 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        consumer1.subscribeAndStart(topic, tag, new RMQOrderListener());
+        consumer2.subscribeAndStart(topic, tag, new RMQOrderListener());
+
+        Assertions.assertNotNull(producer);
+        List<MessageQueue> msgQueues = producer.fetchPublishMessageQueues(topic);
+        List<MessageQueue> msgQueue = new ArrayList<>();
+        msgQueue.add(msgQueues.get(0));
+        producer.sendWithQueue(msgQueue,tag,messageSize);
+
+        await().atMost(120, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return consumer1.getListener().getDequeueMessages().getDataSize() +
+                       consumer2.getListener().getDequeueMessages().getDataSize() == messageSize;
+            }
+        });
+        Assertions.assertTrue(consumer1.getListener().getDequeueMessages().getDataSize() == 0 || consumer2.getListener().getDequeueMessages().getDataSize() == 0, "global sequential message load balancing is not satisfied");
+
+        consumer1.shutdown();
+
+        consumer2.getListener().clearMsg();
+
+        producer.sendWithQueue(msgQueue,tag,messageSize);
+
+        await().atMost(120, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return consumer2.getListener().getDequeueMessages().getDataSize() == messageSize;
+            }
+        });
+
+        Assertions.assertTrue(consumer2.getListener().getDequeueMessages().getDataSize() == messageSize, "global sequential message load balancing is not satisfied");
+
+        producer.shutdown();
+        consumer2.shutdown();
+    }
+
+    @Test
+    @DisplayName("Partition sequential message load balancing, start 4 consumers, send 120 messages, shardingkey=8, expect 4 consumers to consume load balancing, each consumes 1/4 Partition, shutdown 2 of the consumers, send 120 messages again. The load is still balanced, and half of each Partition is consumed")
+    public void testLoadBalancing_partition_sequential_message(){
+        int messageSize = 120;
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        RMQNormalConsumer consumer1 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer2 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer3 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer4 = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        consumer1.subscribeAndStart(topic, tag, new RMQOrderListener());
+        consumer2.subscribeAndStart(topic, tag, new RMQOrderListener());
+        consumer3.subscribeAndStart(topic, tag, new RMQOrderListener());
+        consumer4.subscribeAndStart(topic, tag, new RMQOrderListener());
+
+        Assertions.assertNotNull(producer);
+        for (int i = 0; i < messageSize; i++) {
+            Message message = MessageFactory.buildOneMessageWithTagAndBody(topic, tag, String.valueOf(i));
+            try {
+                SendResult sendResult = producer.getProducer().send(message, new MessageQueueSelector(){
+
+                    @Override
+                    public MessageQueue select(List<MessageQueue> mqs, Message msg, Object arg) {
+                        Integer index = (Integer) arg;
+                        return mqs.get(index % mqs.size());
+                    }
+                    
+                },i);
+                log.info("{}, index: {}, tag: {}", sendResult, i, tag);
+            } catch (Exception e) {
+                Assertions.fail("DefaultMQProducer send message failed");
+            }
+        }
+
+        await().atMost(120, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return consumer1.getListener().getDequeueMessages().getDataSize() +
+                       consumer2.getListener().getDequeueMessages().getDataSize() +
+                       consumer3.getListener().getDequeueMessages().getDataSize() +
+                       consumer4.getListener().getDequeueMessages().getDataSize() == messageSize;
+            }
+        });
+
+        Assertions.assertTrue(messageSize/4==consumer1.getListener().getDequeueMessages().getDataSize(), "consumer1: first load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/4==consumer2.getListener().getDequeueMessages().getDataSize(), "consumer2: first load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/4==consumer3.getListener().getDequeueMessages().getDataSize(), "consumer3: first load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/4==consumer4.getListener().getDequeueMessages().getDataSize(), "consumer4: first load balancing is not satisfied");
+
+        consumer3.shutdown();
+        consumer4.shutdown();
+
+        consumer1.getListener().clearMsg();
+        consumer2.getListener().clearMsg();
+
+        for (int i = 0; i < messageSize; i++) {
+            Message message = MessageFactory.buildOneMessageWithTagAndBody(topic, tag, String.valueOf(i));
+            try {
+                SendResult sendResult = producer.getProducer().send(message, new MessageQueueSelector(){
+
+                    @Override
+                    public MessageQueue select(List<MessageQueue> mqs, Message msg, Object arg) {
+                        Integer index = (Integer) arg;
+                        return mqs.get(index % mqs.size());
+                    }
+                    
+                },i);
+                log.info("{}, index: {}, tag: {}", sendResult, i, tag);
+            } catch (Exception e) {
+                Assertions.fail("DefaultMQProducer send message failed");
+            }
+        }
+
+        await().atMost(120, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return consumer1.getListener().getDequeueMessages().getDataSize() +
+                       consumer2.getListener().getDequeueMessages().getDataSize() == messageSize;
+            }
+        });
+
+        Assertions.assertTrue(messageSize/2==consumer1.getListener().getDequeueMessages().getDataSize(), "consumer1: second load balancing is not satisfied");
+        Assertions.assertTrue(messageSize/2==consumer2.getListener().getDequeueMessages().getDataSize(), "consumer2: second load balancing is not satisfied");
+
+        producer.shutdown();
+        consumer1.shutdown();
+        consumer2.shutdown();
+    }
+}

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/filter/SqlFilterTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/filter/SqlFilterTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.filter;
+
+import org.apache.rocketmq.client.consumer.MessageSelector;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.utils.TestUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+@Tag(TESTSET.SQL)
+@Tag(TESTSET.SMOKE)
+public class SqlFilterTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(SqlFilterTest.class);
+    private final static int SEND_NUM = 10;
+    private RMQNormalProducer producer;
+    private RMQNormalConsumer pushConsumer;
+    private RMQNormalConsumer pullConsumer;
+
+    @BeforeEach
+    public void setUp() {
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (producer != null) {
+            producer.shutdown();
+        }
+        if (pushConsumer != null) {
+            pushConsumer.shutdown();
+        }
+        if (pullConsumer != null) {
+            pullConsumer.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("10 messages are sent synchronously, without any attribute filtering, and expected to be consumed to the 10 messages sent")
+    public void testSendWithTagAndPropsRecvWithOutFilter() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        HashMap<String, String> userProps = new HashMap<>();
+        userProps.put("regionId", "cn-hangzhou");
+        userProps.put("price", "30");
+        String subExpression = "TRUE";
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.bySql(subExpression), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.bySql(subExpression));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildMessageWithProperty(topic, userProps);
+            producer.send(message);
+        }
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("Send 10 messages with the attribute price=10 and 10 messages with the attribute price=30. Set the filtering rule to price>20 and expect only 10 messages to be consumed")
+    public void testSqlSendTwoProps_SubFilterOne() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        HashMap<String, String> userProps1 = new HashMap<>();
+        userProps1.put("price", "10");
+        HashMap<String, String> userProps2 = new HashMap<>();
+        userProps2.put("price", "30");
+        String subExpression = "price>20";
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.bySql(subExpression), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.bySql(subExpression));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildMessageWithProperty(topic, userProps1);
+            producer.send(message);
+        }
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildMessageWithProperty(topic, userProps2);
+            producer.send(message);
+        }
+        VerifyUtils.verifyNormalMessageWithUserProperties(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages(), userProps1, 10);
+    }
+
+    @Test
+    @DisplayName("Send 10 messages synchronously, using the attribute between{a,b} filter, expect to consume 10 messages sent")
+    public void testSendWithTagAndPropsRecvWithBetween() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        HashMap<String, String> userProps = new HashMap<>();
+        userProps.put("regionId", "cn-hangzhou");
+        userProps.put("price", "30");
+        String subExpression = "(price BETWEEN 10 AND 100) AND regionId IS NOT NUll";
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.bySql(subExpression), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.bySql(subExpression));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildMessageWithProperty(topic, userProps);
+            producer.send(message);
+        }
+
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("Send 10 messages synchronously, filter messages using unknown attributes, expect to consume up to 0 messages")
+    public void testSendWithTagAndPropsRecvWithUnknownProps() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        HashMap<String, String> userProps = new HashMap<>();
+        userProps.put("regionId", "cn-hangzhou");
+        userProps.put("price", "30");
+        String subExpression = "product = 'MQ'";
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.bySql(subExpression), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.bySql(subExpression));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildMessageWithProperty(topic, userProps);
+            producer.send(message);
+        }
+        TestUtils.waitForSeconds(20);
+        Assertions.assertEquals(0, pushConsumer.getListener().getDequeueMessages().getDataSize());
+    }
+
+}
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/filter/SqlFilterTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/filter/SqlFilterTest.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 
 @Tag(TESTSET.SQL)
-@Tag(TESTSET.SMOKE)
 public class SqlFilterTest extends BaseOperate {
     private final Logger log = LoggerFactory.getLogger(SqlFilterTest.class);
     private final static int SEND_NUM = 10;
@@ -76,11 +75,6 @@ public class SqlFilterTest extends BaseOperate {
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.bySql(subExpression), new RMQNormalListener());
 
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.bySql(subExpression));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
 
@@ -107,11 +101,6 @@ public class SqlFilterTest extends BaseOperate {
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.bySql(subExpression), new RMQNormalListener());
 
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.bySql(subExpression));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
 
@@ -123,7 +112,8 @@ public class SqlFilterTest extends BaseOperate {
             Message message = MessageFactory.buildMessageWithProperty(topic, userProps2);
             producer.send(message);
         }
-        VerifyUtils.verifyNormalMessageWithUserProperties(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages(), userProps1, 10);
+        VerifyUtils.verifyNormalMessageWithUserProperties(producer.getEnqueueMessages(),
+                pushConsumer.getListener().getDequeueMessages(), userProps1, 10);
     }
 
     @Test
@@ -140,11 +130,6 @@ public class SqlFilterTest extends BaseOperate {
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.bySql(subExpression), new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.bySql(subExpression));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
@@ -172,11 +157,6 @@ public class SqlFilterTest extends BaseOperate {
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.bySql(subExpression), new RMQNormalListener());
 
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.bySql(subExpression));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
 
@@ -189,4 +169,3 @@ public class SqlFilterTest extends BaseOperate {
     }
 
 }
-

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/filter/TagFilterTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/filter/TagFilterTest.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.filter;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.rocketmq.client.consumer.MessageSelector;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.TestUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@DisplayName("TAG filtering test: Use PushConsumer for consumption")
+@Tag(TESTSET.TAG)
+@Tag(TESTSET.SMOKE)
+public class TagFilterTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(TagFilterTest.class);
+    private final static int SEND_NUM = 10;
+    RMQNormalProducer producer;
+    RMQNormalConsumer pushConsumer;
+    RMQNormalConsumer pullConsumer;
+
+    @BeforeEach
+    public void setUp() {
+
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (producer != null) {
+            producer.shutdown();
+        }
+        if (pushConsumer != null) {
+            pushConsumer.shutdown();
+        }
+        if (pullConsumer != null) {
+            pullConsumer.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("Using tagA sent 10 messages, the use of tagA | | tagB filter messages, expect consumption to send 10 messages")
+    public void testSendTagA_SubTagAorTagB() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTag = NameUtils.getRandomTagName();
+        String receiveTag = sendTag + "||TagB";
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        producer.send(topic, sendTag, SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("Use tagA sent 10 messages first, after using tagB sent 10 messages, use tagA | | tagB filter messages, expect consumption to send 20 messages")
+    public void testSndTagATagB_SubTagATagB() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTagA = NameUtils.getRandomTagName();
+        String sendTagB = NameUtils.getRandomTagName();
+        String receiveTag = sendTagA + "||" + sendTagB;
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        producer.send(topic, sendTagA, SEND_NUM);
+        producer.send(topic, sendTagB, SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM * 2, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("The tagA is used to send 10 messages, then the tagB is used to send 10 messages, and the * is used to filter the messages, expecting to consume 20 messages sent")
+    public void testSendTagAAndTagB_SubAll() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTagA = NameUtils.getRandomTagName();
+        String sendTagB = NameUtils.getRandomTagName();
+        String receiveTag = "*";
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        producer.send(topic, sendTagA, SEND_NUM);
+        producer.send(topic, sendTagB, SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM * 2, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("Send 10 tagA messages, subscribe to tagB messages, expect to consume up to 0 messages")
+    public void testSendTagA_SubTagB() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTagA = NameUtils.getRandomTagName();
+        String receiveTag = NameUtils.getRandomTagName();
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        producer.send(topic, sendTagA, SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        TestUtils.waitForSeconds(20);
+        Assertions.assertEquals(0, pushConsumer.getListener().getDequeueMessages().getDataSize());
+    }
+
+    @Test
+    @DisplayName("Send 10 tagA messages, subscribe to tagA messages, expect to consume up to 10 messages")
+    public void testSendTagA_SubTagA() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTag = NameUtils.getRandomTagName();
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(sendTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(sendTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        Assertions.assertNotNull(producer);
+        producer.send(topic, sendTag, SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("Consumption uses a very long tagA, sending 10 messages, expecting to consume 10 tagA messages")
+    public void testLongTagSize() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTag = RandomStringUtils.randomAlphanumeric(1024 * 10);
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(sendTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(sendTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        producer.send(topic, sendTag, SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("The consumption uses a space-spaced tag, and two tags are used to send 10 messages each, with the expectation of consuming up to 20 messages")
+    public void testSubTagWithSpace() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTagA = NameUtils.getRandomTagName();
+        String sendTagB = NameUtils.getRandomTagName();
+        String receiveTag = " " + sendTagA + " || " + sendTagB + " ";
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        producer.send(topic, sendTagA, SEND_NUM);
+        producer.send(topic, sendTagB, SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM * 2, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Disabled
+    @DisplayName("Send 10 tag = '@ | | | @' news, expect to send an exception is thrown, the tag is not allowed to include |")
+    public void testTagWithSpecialSymbol01() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        Assertions.assertThrows(Exception.class, () -> {
+            producer.send(topic, "|@", SEND_NUM);
+        }, "Send messages with  tag \"|@\", Expected send() to throw exception, but it didn't");
+    }
+
+    @Test
+    @DisplayName("Send 10 messages with tag='*', subscribe to messages with tag='*', expect to consume the message")
+    public void testTagWithSpecialSymbol02() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag("*"), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag("*"));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+        producer.send(topic, "*", SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Test
+    @DisplayName("Consumer use | | separators between the tag, respectively using two tag each 10 messages sent, and expect consumption to 20 messages")
+    public void testTagWithSpecialSymbol03() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTagA = NameUtils.getRandomTagName();
+        String sendTagB = NameUtils.getRandomTagName();
+        String receiveTag = sendTagA + "||||" + sendTagB;
+
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+        producer.send(topic, sendTagA, SEND_NUM);
+        producer.send(topic, sendTagB, SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM * 2, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+    }
+
+    @Disabled
+    @DisplayName("Send 10 messages each using the whitespace characters tag\"\" and \"\", expecting the send to throw an exception")
+    public void testTagWithBlankSymbol() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+
+        String sendTagA = "";
+        String sendTagB = " ";
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+        Assertions.assertThrows(Exception.class, () -> {
+            producer.send(topic, sendTagA, SEND_NUM);
+        }, "Send messages with blank tag \"\", Expected send() to throw exception, but it didn't");
+        Assertions.assertThrows(Exception.class, () -> {
+            producer.send(topic, sendTagB, SEND_NUM);
+        }, "Send messages with blank tag \" \", Expected send() to throw exception, but it didn't");
+    }
+
+    @Test
+    @DisplayName("The sent tag uses two strings with the same hash value, and the consumed tag uses BB, expecting to consume messages with tag=BB")
+    public void testSendTagWithSameHashCode_SubWithOne() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTagA = "BB";
+        String sendTagB = "Aa";
+        String receiveTag = "BB";
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+        producer.send(topic, sendTagA, SEND_NUM);
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+        pushConsumer.getListener().clearMsg();
+        producer.send(topic, sendTagB, SEND_NUM);
+        TestUtils.waitForSeconds(10);
+        Assertions.assertEquals(0, pushConsumer.getListener().getDequeueAllMessages().getDataSize());
+    }
+
+    @Test
+    @DisplayName("Send 10 messages with tag=BB, 10 messages with tag=bb, subscribe with tag=BB, expect case-sensitive messages to be consumed to tag=BB")
+    public void testTagCaseSensitive() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        String sendTagA = "BB";
+        String sendTagB = "bb";
+        String receiveTag = "BB";
+        pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
+
+        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+        producer.send(topic, sendTagA, SEND_NUM);
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+        pushConsumer.getListener().clearMsg();
+        producer.send(topic, sendTagB, SEND_NUM);
+        TestUtils.waitForSeconds(10);
+        Assertions.assertEquals(0, pushConsumer.getListener().getDequeueAllMessages().getDataSize());
+    }
+}
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/filter/TagFilterTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/filter/TagFilterTest.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 @DisplayName("TAG filtering test: Use PushConsumer for consumption")
 @Tag(TESTSET.TAG)
-@Tag(TESTSET.SMOKE)
 public class TagFilterTest extends BaseOperate {
     private final Logger log = LoggerFactory.getLogger(TagFilterTest.class);
     private final static int SEND_NUM = 10;
@@ -74,11 +73,6 @@ public class TagFilterTest extends BaseOperate {
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
 
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
 
@@ -101,11 +95,6 @@ public class TagFilterTest extends BaseOperate {
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
@@ -131,11 +120,6 @@ public class TagFilterTest extends BaseOperate {
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
 
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
 
@@ -158,11 +142,6 @@ public class TagFilterTest extends BaseOperate {
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
@@ -187,7 +166,7 @@ public class TagFilterTest extends BaseOperate {
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(sendTag), new RMQNormalListener());
 
         pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(sendTag));
+        pullConsumer.subscribeAndStartLitePull(topic, MessageSelector.byTag(sendTag));
         VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
         pullConsumer.shutdown();
 
@@ -213,11 +192,6 @@ public class TagFilterTest extends BaseOperate {
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(sendTag), new RMQNormalListener());
 
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(sendTag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
 
@@ -240,11 +214,6 @@ public class TagFilterTest extends BaseOperate {
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
@@ -280,11 +249,6 @@ public class TagFilterTest extends BaseOperate {
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag("*"), new RMQNormalListener());
 
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag("*"));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
         producer.send(topic, "*", SEND_NUM);
@@ -306,11 +270,6 @@ public class TagFilterTest extends BaseOperate {
 
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
-
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
 
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
@@ -353,11 +312,6 @@ public class TagFilterTest extends BaseOperate {
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
 
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
         producer.send(topic, sendTagA, SEND_NUM);
@@ -381,11 +335,6 @@ public class TagFilterTest extends BaseOperate {
         pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(receiveTag), new RMQNormalListener());
 
-        pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(receiveTag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
         producer.send(topic, sendTagA, SEND_NUM);
@@ -396,4 +345,3 @@ public class TagFilterTest extends BaseOperate {
         Assertions.assertEquals(0, pushConsumer.getListener().getDequeueAllMessages().getDataSize());
     }
 }
-

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/offset/OffsetTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/offset/OffsetTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.offset;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.MessageSelector;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.apache.rocketmq.server.batch.BatchProducerTest;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.apache.rocketmq.utils.TestUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+
+@Tag(TESTSET.OFFSET)
+@Tag(TESTSET.SMOKE)
+public class OffsetTest extends BaseOperate{
+    private final Logger log = LoggerFactory.getLogger(OffsetTest.class);
+    private String tag;
+    private final static int SEND_NUM = 10;
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+    }
+
+    @Test
+    @DisplayName("Send 10 messages, set other groupid's pushconsumer consumption from first, expect to accept all messages again")
+    public void testConsumeFromFisrtOffset(){
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId1 = getGroupId(methodName);
+        String groupId2 = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId1, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        DefaultMQPushConsumer pushConsumer;
+        ConcurrentLinkedDeque<MessageExt> deque = new ConcurrentLinkedDeque<>();
+        try{
+            pushConsumer = new DefaultMQPushConsumer(groupId1, rpcHook, new AllocateMessageQueueAveragely());
+            pushConsumer.setInstanceName(RandomUtils.getStringByUUID());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe(topic, tag);
+            pushConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET);
+            pushConsumer.setMessageListener(new MessageListenerConcurrently() {
+                @Override
+                public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs, ConsumeConcurrentlyContext context) {
+                    for (MessageExt message : msgs) {
+                        log.info("receive message:{}", message);
+                        deque.add(message);
+                    }
+                    return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+                }
+            });
+            pushConsumer.start();
+        } catch (MQClientException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assertions.assertNotNull(producer);
+
+        producer.send(topic, tag, SEND_NUM);
+
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+
+        await().atMost(30, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return deque.size() == SEND_NUM;
+            }
+        });
+
+        pushConsumer.shutdown();
+        deque.clear();
+
+        DefaultMQPushConsumer reConsumer;
+        try{
+            reConsumer = new DefaultMQPushConsumer(groupId2, rpcHook, new AllocateMessageQueueAveragely());
+            reConsumer.setInstanceName(RandomUtils.getStringByUUID());
+            reConsumer.setNamesrvAddr(namesrvAddr);
+            reConsumer.subscribe(topic, tag);
+            reConsumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET);
+            reConsumer.setMessageListener(new MessageListenerConcurrently() {
+                @Override
+                public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs, ConsumeConcurrentlyContext context) {
+                    for (MessageExt message : msgs) {
+                        log.info("reconsumer received message:{}", message);
+                        deque.add(message);
+                    }
+                    return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+                }
+            });
+            reConsumer.start();
+        } catch (MQClientException e) {
+            throw new RuntimeException(e);
+        }
+
+        TestUtils.waitForSeconds(30);
+
+       Assertions.assertEquals(SEND_NUM, deque.size(), "reconsumer receive message failed");
+
+        reConsumer.shutdown();
+        producer.shutdown();
+
+    }
+
+    @Test
+    @DisplayName("send 10 messages, PullConsumer normally receives messages, but does not update messages offset, expect the messages are receive again")
+    public void test_pull_receive_nack() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr,groupId, rpcHook);
+        consumer.startDefaultPull();
+        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(),topic,tag,32);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        producer.send(topic,tag,SEND_NUM);
+
+        TestUtils.waitForSeconds(1);
+
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+
+        Set<MessageQueue> receiveMessageQueues = null;
+        try {
+            receiveMessageQueues = consumer.getPullConsumer().fetchSubscribeMessageQueues(topic);
+        } catch (MQClientException e) {
+            Assertions.fail("Fail to fetchSubscribeMessageQueues");
+        }
+
+        Collection<MessageExt> sendCollection = Collections.synchronizedCollection(producer.getEnqueueMessages().getAllData());
+        Set<MessageQueue> finalMessageQueues = receiveMessageQueues;
+        CompletableFuture[] futures = new CompletableFuture[receiveMessageQueues.size()];
+        ConcurrentHashMap<String,AtomicInteger> messageMap = new ConcurrentHashMap<>();
+        int mqCount = 0;
+        for (MessageQueue mq : finalMessageQueues) {
+            CompletableFuture<Void> future = CompletableFuture.supplyAsync(() -> {
+                try {
+                    long offset = consumer.getPullConsumer().fetchConsumeOffset(mq, false);
+                    if (offset < 0) return null;
+                    long startTime = System.currentTimeMillis();
+                    while (System.currentTimeMillis() < startTime + 5000) {
+                        PullResult pullResult = consumer.getPullConsumer().pull(mq, tag, offset, SEND_NUM);
+                        switch (pullResult.getPullStatus()) {
+                            case FOUND:
+                                List<MessageExt> messages = pullResult.getMsgFoundList();
+                                for (MessageExt message : messages) {
+                                    log.info("MessageId:{}, Body:{}, Property:{}, Retry:{}", message.getMsgId(),
+                                            StandardCharsets.UTF_8.decode(ByteBuffer.wrap(message.getBody())), message.getProperties(), message.getReconsumeTimes());
+                                    sendCollection.removeIf(messageExt -> messageExt.getMsgId().equals(message.getMsgId()));
+                                    if(messageMap.containsKey(message.getMsgId())){
+                                        messageMap.get(message.getMsgId()).incrementAndGet();
+                                    }else{
+                                        messageMap.put(message.getMsgId(),new AtomicInteger(1));
+                                    }
+                                }
+                                break;
+                            case NO_MATCHED_MSG:
+                                break;
+                            case NO_NEW_MSG:
+                                break;
+                            case OFFSET_ILLEGAL:
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                } catch (MQBrokerException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (RemotingException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (MQClientException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                }
+                return null;
+            });
+            futures[mqCount++] = future;
+        }
+        try {
+            CompletableFuture.allOf(futures).get(60, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail("receive response count not match");
+        }
+        log.info("A total of {} messages were received", messageMap.size());
+        for (Entry<String,AtomicInteger> entry : messageMap.entrySet()) {
+            Assertions.assertTrue(entry.getValue().get() >= 1, "message receive count not match");
+        }
+    }
+}

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullAckTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullAckTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.pull;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.TestUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag(TESTSET.NORMAL)
+@Tag(TESTSET.PULL)
+@Tag(TESTSET.SMOKE)
+public class PullAckTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(PullAckTest.class);
+    private String tag;
+    private final static int SEND_NUM = 20;
+    private RMQNormalProducer producer;
+
+    @BeforeAll
+    public static void setUpAll() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+        log.info("tag:{}", tag);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (producer != null) {
+            producer.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(180)
+    @DisplayName("Send 20 normal messages synchronously and expect lite pull consumer to consume with receive and ack messages successful")
+    public void testNormal_lite_pull_receive_ack() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.startLitePullAssignMode();
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, tag + "-" + i);
+            producer.send(message);
+        }
+        TestUtils.waitForSeconds(1);
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.waitLitePullReceiveThenAck(producer, pullConsumer.getLitePullConsumer(),topic,tag);
+    }
+
+    @Test
+    @Timeout(180)
+    @DisplayName("Send 20 normal messages synchronously and expect pull consumer to consume with receive and ack messages successful")
+    public void testNormal_pull_receive_ack() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr,groupId, rpcHook);
+        consumer.startDefaultPull();
+        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(),topic,tag,32);
+        producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, tag + "-" + i);
+            producer.send(message);
+        }
+        TestUtils.waitForSeconds(1);
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.waitPullReceiveThenAck(producer, consumer.getPullConsumer(), topic,tag,32);
+    }
+
+}
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullAckTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullAckTest.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 @Tag(TESTSET.NORMAL)
 @Tag(TESTSET.PULL)
-@Tag(TESTSET.SMOKE)
 public class PullAckTest extends BaseOperate {
     private final Logger log = LoggerFactory.getLogger(PullAckTest.class);
     private String tag;
@@ -68,7 +67,7 @@ public class PullAckTest extends BaseOperate {
         String topic = getTopic(methodName);
         String groupId = getGroupId(methodName);
 
-        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook, 1);
         pullConsumer.startLitePullAssignMode();
         VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
 
@@ -81,7 +80,7 @@ public class PullAckTest extends BaseOperate {
         }
         TestUtils.waitForSeconds(1);
         Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
-        VerifyUtils.waitLitePullReceiveThenAck(producer, pullConsumer.getLitePullConsumer(),topic,tag);
+        VerifyUtils.waitLitePullReceiveThenAck(producer, pullConsumer.getLitePullConsumer(), topic, tag);
     }
 
     @Test
@@ -93,9 +92,9 @@ public class PullAckTest extends BaseOperate {
         String topic = getTopic(methodName);
         String groupId = getGroupId(methodName);
 
-        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr,groupId, rpcHook);
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr, groupId, rpcHook);
         consumer.startDefaultPull();
-        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(),topic,tag,32);
+        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(), topic, tag, 32);
         producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
         for (int i = 0; i < SEND_NUM; i++) {
@@ -104,8 +103,7 @@ public class PullAckTest extends BaseOperate {
         }
         TestUtils.waitForSeconds(1);
         Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
-        VerifyUtils.waitPullReceiveThenAck(producer, consumer.getPullConsumer(), topic,tag,32);
+        VerifyUtils.waitPullReceiveThenAck(producer, consumer.getPullConsumer(), topic, tag, 32);
     }
 
 }
-

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullOrderParamTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullOrderParamTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.pull;
+
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.TestUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@Tag(TESTSET.PULL)
+@Tag(TESTSET.SMOKE)
+public class PullOrderParamTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(PullOrderParamTest.class);
+    private String tag;
+    private String groupId;
+    private final static int SEND_NUM = 20;
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+        groupId = NameUtils.getRandomGroupName();
+        log.info("tag:{}, groupId:{}", tag, groupId);
+    }
+
+    @AfterEach
+    public void tearDown() {
+    }
+
+    @Test
+    @DisplayName("When sending 20 sequential messages synchronously using the same MessageQueue, PullConsumer normally receives messages, but does not ack messages, and keeps the sequence; the messages are stuck at the first")
+    public void testFIFO_pull_receive_nack() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr,groupId, rpcHook);
+        consumer.startDefaultPull();
+        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(),topic,tag,32);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        List<MessageQueue> messageQueues = producer.fetchPublishMessageQueues(topic);
+        List<MessageQueue> messageGroup = new ArrayList<>();
+        messageGroup.add(messageQueues.get(0));
+        producer.sendWithQueue(messageGroup,tag,SEND_NUM);
+
+        TestUtils.waitForSeconds(1);
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+
+        Set<MessageQueue> receiveMessageQueues = null;
+        try {
+            receiveMessageQueues = consumer.getPullConsumer().fetchSubscribeMessageQueues(topic);
+        } catch (MQClientException e) {
+            Assertions.fail("Fail to fetchSubscribeMessageQueues");
+        }
+
+        Collection<MessageExt> sendCollection = Collections.synchronizedCollection(producer.getEnqueueMessages().getAllData());
+        Set<MessageQueue> finalMessageQueues = receiveMessageQueues;
+        CompletableFuture[] futures = new CompletableFuture[receiveMessageQueues.size()];
+        List<MessageExt> receivedMessage = new ArrayList<>();
+        int mqCount = 0;
+        for (MessageQueue mq : finalMessageQueues) {
+            CompletableFuture<Void> future = CompletableFuture.supplyAsync(() -> {
+                try {
+                    long offset = consumer.getPullConsumer().fetchConsumeOffset(mq, false);
+                    if (offset < 0) return null;
+                    long startTime = System.currentTimeMillis();
+                    while (System.currentTimeMillis() < startTime + 30000) {
+                        PullResult pullResult = consumer.getPullConsumer().pull(mq, tag, offset, 1);
+                        switch (pullResult.getPullStatus()) {
+                            case FOUND:
+                                List<MessageExt> messages = pullResult.getMsgFoundList();
+                                for (MessageExt message : messages) {
+                                    log.info("MessageId:{}, Body:{}, Property:{}, Retry:{}", message.getMsgId(),
+                                            StandardCharsets.UTF_8.decode(ByteBuffer.wrap(message.getBody())), message.getProperties(), message.getReconsumeTimes());
+                                    sendCollection.removeIf(messageExt -> messageExt.getMsgId().equals(message.getMsgId()));
+                                    receivedMessage.add(message);
+                                }
+                                break;
+                            case NO_MATCHED_MSG:
+                                break;
+                            case NO_NEW_MSG:
+                                break;
+                            case OFFSET_ILLEGAL:
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                } catch (MQBrokerException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (RemotingException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (MQClientException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                }
+                return null;
+            });
+            futures[mqCount++] = future;
+        }
+        try {
+            CompletableFuture.allOf(futures).get(60, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail("receive response count not match");
+        }
+        log.info("A total of {} messages were received", receivedMessage.size());
+        for (MessageExt ext : receivedMessage) {
+            if (!StandardCharsets.UTF_8.decode(ByteBuffer.wrap(ext.getBody())).toString().equals("0")) {
+                Assertions.fail(String.format("Consumption out of order, expected :Body=%s Actual :Body=%s", 0, StandardCharsets.UTF_8.decode(ByteBuffer.wrap(ext.getBody()))));
+            }
+        }
+    }
+}
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullOrderTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullOrderTest.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Tag(TESTSET.PULL)
-@Tag(TESTSET.SMOKE)
 public class PullOrderTest extends BaseOperate {
     private final Logger log = LoggerFactory.getLogger(PullOrderTest.class);
     private String tag;
@@ -59,20 +58,19 @@ public class PullOrderTest extends BaseOperate {
         String topic = getTopic(methodName);
         String groupId = getGroupId(methodName);
 
-        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr,groupId, rpcHook);
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr, groupId, rpcHook);
         consumer.startDefaultPull();
-        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(),topic,tag,32);
+        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(), topic, tag, 32);
         RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
         Assertions.assertNotNull(producer, "Get producer failed");
 
         List<MessageQueue> messageQueues = producer.fetchPublishMessageQueues(topic);
         List<MessageQueue> messageGroup = new ArrayList<>();
         messageGroup.add(messageQueues.get(0));
-        producer.sendWithQueue(messageGroup,tag,SEND_NUM);
+        producer.sendWithQueue(messageGroup, tag, SEND_NUM);
         TestUtils.waitForSeconds(1);
         Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
-        VerifyUtils.waitFIFOReceiveThenAck(producer, consumer.getPullConsumer(), topic,tag,5);
+        VerifyUtils.waitFIFOReceiveThenAck(producer, consumer.getPullConsumer(), topic, tag, 5);
     }
 
 }
-

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullOrderTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullOrderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.pull;
+
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.TestUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Tag(TESTSET.PULL)
+@Tag(TESTSET.SMOKE)
+public class PullOrderTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(PullOrderTest.class);
+    private String tag;
+    private String groupId;
+    private final static int SEND_NUM = 20;
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+        groupId = NameUtils.getRandomGroupName();
+        log.info("tag:{}, groupId:{}", tag, groupId);
+    }
+
+    @Test
+    @DisplayName("Send 20 sequential messages synchronously, and expect PullConsumer to receive and ack messages properly and maintain the sequence")
+    public void testFIFO_simple_receive_ack() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr,groupId, rpcHook);
+        consumer.startDefaultPull();
+        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(),topic,tag,32);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        List<MessageQueue> messageQueues = producer.fetchPublishMessageQueues(topic);
+        List<MessageQueue> messageGroup = new ArrayList<>();
+        messageGroup.add(messageQueues.get(0));
+        producer.sendWithQueue(messageGroup,tag,SEND_NUM);
+        TestUtils.waitForSeconds(1);
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.waitFIFOReceiveThenAck(producer, consumer.getPullConsumer(), topic,tag,5);
+    }
+
+}
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullParamTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullParamTest.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.pull;
+
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.apache.rocketmq.utils.TestUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.apache.rocketmq.utils.data.collect.DataCollector;
+import org.apache.rocketmq.utils.data.collect.DataCollectorManager;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@Tag(TESTSET.PULL)
+@Tag(TESTSET.SMOKE)
+public class PullParamTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(PullParamTest.class);
+    private String tag;
+    private String groupId;
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+        groupId = NameUtils.getRandomGroupName();
+        log.info("tag:{}, groupId:{}", tag, groupId);
+    }
+
+    @AfterEach
+    public void tearDown() {
+    }
+
+    @Test
+    @DisplayName("Send 300 normal messages synchronously, and after using PullConsumer receive 30 messages, ack them after consuming them, expecting each receive to be less than or equal to 32 messages, and never receive the ack messages again")
+    public void testNormal_pull_receive_maxsize_sync() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        int sendNum = 300;
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr,groupId, rpcHook);
+        consumer.startDefaultPull();
+        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(),topic,tag,32);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        for (int i = 0; i < sendNum; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, RandomUtils.getStringByUUID());
+            producer.send(message);
+        }
+        Assertions.assertEquals(sendNum, producer.getEnqueueMessages().getDataSize(), "send message failed");
+
+        Set<MessageQueue> receiveMessageQueues = null;
+        try {
+            receiveMessageQueues = consumer.getPullConsumer().fetchSubscribeMessageQueues(topic);
+        } catch (MQClientException e) {
+            Assertions.fail("Fail to fetchSubscribeMessageQueues");
+        }
+
+        Set<MessageQueue> finalMessageQueues = receiveMessageQueues;
+        CompletableFuture[] futures = new CompletableFuture[receiveMessageQueues.size()];
+        Map<String, MessageExt> recvMsgs = new ConcurrentHashMap<>();
+        int mqCount = 0;
+        for (MessageQueue mq : finalMessageQueues) {
+            CompletableFuture<Void> future = CompletableFuture.supplyAsync(() -> {
+                try {
+                    long offset = consumer.getPullConsumer().fetchConsumeOffset(mq, false);
+                    if (offset < 0) return null;
+                    boolean shouldContinue = true;
+                    while (shouldContinue) {
+                        PullResult pullResult = consumer.getPullConsumer().pull(mq, tag, offset, 50);
+                        switch (pullResult.getPullStatus()) {
+                            case FOUND:
+                                List<MessageExt> messages = pullResult.getMsgFoundList();
+                                Assertions.assertTrue(messages.size() <= 32);
+                                for (MessageExt message : messages) {
+                                    log.info("MessageId:{}, Body:{}, Property:{}, Retry:{}", message.getMsgId(),
+                                            StandardCharsets.UTF_8.decode(ByteBuffer.wrap(message.getBody())), message.getProperties(), message.getReconsumeTimes());
+                                    if (recvMsgs.containsKey(message.getMsgId())) {
+                                        Assertions.fail("Consume an ack message: "+message.getMsgId());
+                                    } else {
+                                        recvMsgs.put(message.getMsgId(), message);
+                                    }
+                                }
+                                offset = pullResult.getNextBeginOffset();
+                                consumer.getPullConsumer().updateConsumeOffset(mq,offset);
+                                break;
+                            case NO_MATCHED_MSG:
+                                shouldContinue = false; // 当没有匹配的消息时退出循环
+                                break;
+                            case NO_NEW_MSG:
+                                shouldContinue = false; // 当没有新的消息时退出循环
+                                break;
+                            case OFFSET_ILLEGAL:
+                                shouldContinue = false; // 当偏移量非法时退出循环
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                } catch (MQBrokerException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (RemotingException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (MQClientException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                }
+                return null;
+            });
+            futures[mqCount++] = future;
+        }
+        try {
+            CompletableFuture.allOf(futures).get(60, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail("receive response count not match");
+        }
+        DataCollector dequeueMessages = DataCollectorManager.getInstance().fetchListDataCollector(RandomUtils.getStringByUUID());
+        for (MessageExt messageExt : recvMsgs.values()) {
+            dequeueMessages.addData(messageExt);
+        }
+        log.info("{} messages are received", dequeueMessages.getDataSize());
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), dequeueMessages, 10);
+    }
+
+    @Test
+    @DisplayName("Twenty ordinary messages are sent synchronously, and receive(50) messages are received in batch. All the pulled messages are ack() messages except the last one. expected the ack messages will not be consumed repeatedly")
+    public void testNormal_simple_receive_multi_nack() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        int sendNum = 20;
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQPullConsumer(namesrvAddr,groupId, rpcHook);
+        consumer.startDefaultPull();
+        VerifyUtils.tryReceiveOnce(consumer.getPullConsumer(),topic,tag,32);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+
+        for (int i = 0; i < sendNum; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
+            producer.send(message);
+        }
+        Assertions.assertEquals(sendNum, producer.getEnqueueMessages().getDataSize(), "send message failed");
+
+        Set<MessageQueue> receiveMessageQueues = null;
+        try {
+            receiveMessageQueues = consumer.getPullConsumer().fetchSubscribeMessageQueues(topic);
+        } catch (MQClientException e) {
+            Assertions.fail("Fail to fetchSubscribeMessageQueues");
+        }
+
+        Map<String, MessageExt> recvMsgs = new ConcurrentHashMap<>();
+        Set<String> unconsumedMsgIds = new HashSet<>();
+        boolean[] flag = {true};
+        Set<MessageQueue> finalMessageQueues = receiveMessageQueues;
+        CompletableFuture[] futures = new CompletableFuture[receiveMessageQueues.size()];
+        int mqCount = 0;
+        for (MessageQueue mq : finalMessageQueues) {
+            CompletableFuture<Void> future = CompletableFuture.supplyAsync(() -> {
+                try {
+                    long offset = consumer.getPullConsumer().fetchConsumeOffset(mq, false);
+                    if (offset < 0) return null;
+                    long startTime = System.currentTimeMillis();
+                    while (System.currentTimeMillis() < startTime + 40000) {
+                        PullResult pullResult = consumer.getPullConsumer().pull(mq, tag, offset, 50);
+                        switch (pullResult.getPullStatus()) {
+                            case FOUND:
+                                List<MessageExt> messages = pullResult.getMsgFoundList();
+                                Assertions.assertTrue(messages.size() <= 32);
+                                for (MessageExt message : messages) {
+                                    log.info("MessageId:{}, Body:{}, Property:{}, Retry:{}", message.getMsgId(),
+                                            StandardCharsets.UTF_8.decode(ByteBuffer.wrap(message.getBody())), message.getProperties(), message.getReconsumeTimes());
+                                    int msgId = Integer.parseInt(String.valueOf(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(message.getBody()))));
+                                    if (msgId == 19 && flag[0]) {
+                                        flag[0] = false;
+                                        unconsumedMsgIds.add(message.getMsgId());
+                                        log.info("nack message:{} {}", StandardCharsets.UTF_8.decode(ByteBuffer.wrap(message.getBody())),message);
+                                    } else {
+                                        if(msgId==19){
+                                            unconsumedMsgIds.add(message.getMsgId());
+                                        }else{
+                                            consumer.getPullConsumer().updateConsumeOffset(mq, ++offset);
+                                            if (recvMsgs.containsKey(message.getMsgId())) {
+                                                Assertions.fail("Consume an ack message");
+                                            } else {
+                                                recvMsgs.put(message.getMsgId(), message);
+                                            }
+                                        }
+                                    }
+                                }
+                                if(messages.size()!=1 || Integer.parseInt(String.valueOf(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(messages.get(0).getBody()))))!=19) {
+                                    return null;
+                                }
+                                break;
+                            case NO_MATCHED_MSG:
+                                break;
+                            case NO_NEW_MSG:
+                                break;
+                            case OFFSET_ILLEGAL:
+                                break;
+                            default:
+                                break;
+                        }
+                        if (recvMsgs.size() == sendNum) {
+                            break;
+                        }
+                    }
+                } catch (MQBrokerException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (RemotingException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                } catch (MQClientException e) {
+                    e.printStackTrace();
+                    Assertions.fail("Pull fetch message error");
+                }
+                return null;
+            });
+            futures[mqCount++] = future;
+        }
+        try {
+            CompletableFuture.allOf(futures).get(60, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail("receive response count not match");
+        }
+
+        DataCollector dequeueMessages = DataCollectorManager.getInstance().fetchListDataCollector(RandomUtils.getStringByUUID());
+        for (MessageExt messageExt : recvMsgs.values()) {
+            dequeueMessages.addData(messageExt);
+        }
+
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), dequeueMessages, unconsumedMsgIds, 10);
+
+    }
+
+}
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullParamTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/pull/PullParamTest.java
@@ -124,13 +124,13 @@ public class PullParamTest extends BaseOperate {
                                 consumer.getPullConsumer().updateConsumeOffset(mq, offset);
                                 break;
                             case NO_MATCHED_MSG:
-                                shouldContinue = false; // 当没有匹配的消息时退出循环
+                                shouldContinue = false;
                                 break;
                             case NO_NEW_MSG:
-                                shouldContinue = false; // 当没有新的消息时退出循环
+                                shouldContinue = false;
                                 break;
                             case OFFSET_ILLEGAL:
-                                shouldContinue = false; // 当偏移量非法时退出循环
+                                shouldContinue = false;
                                 break;
                             default:
                                 break;

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/server/abnormal/PushConsumerRetryTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/server/abnormal/PushConsumerRetryTest.java
@@ -1,0 +1,416 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.server.abnormal;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.MessageSelector;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListener;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly;
+import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.RandomUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.apache.rocketmq.utils.TestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag(TESTSET.RETRY)
+@Tag(TESTSET.SMOKE)
+public class PushConsumerRetryTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(PushConsumerRetryTest.class);
+    private String tag;
+    private final static int SEND_NUM = 5;
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+    }
+
+    @Test
+    @DisplayName("Simulate pushconsumer consumption fail, expect that the original message was not received, and capture all messages after message retry")
+    public void testExceptionConsumption(){
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        Map<String, MessageExt> firstMsgs = new ConcurrentHashMap<>();
+        Map<String, MessageExt> retryMsgs = new ConcurrentHashMap<>();
+
+        DefaultMQPushConsumer pushConsumer;
+        try{
+            pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook, new AllocateMessageQueueAveragely());
+            pushConsumer.setInstanceName(RandomUtils.getStringByUUID());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe(topic, tag);
+            pushConsumer.setMessageModel(MessageModel.CLUSTERING);
+            pushConsumer.setMaxReconsumeTimes(2);
+            pushConsumer.setMessageListener(new MessageListenerConcurrently(){
+                @Override
+                public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
+                        ConsumeConcurrentlyContext context) {
+                    for (MessageExt msg : msgs) {
+                        if(msg.getReconsumeTimes() == 2){
+                            retryMsgs.putIfAbsent(msg.getMsgId(), msg);
+                            log.info("consume success: {}",msg);
+                        }else{
+                            // Simulate consuming operations
+                            log.info("{}","Simulate consuming operations fail");
+                            int i = 1/0;
+                            log.info("{}","Simulate consuming operations fail end");
+                            firstMsgs.putIfAbsent(msg.getMsgId(), msg);
+                            log.info(String.format("recv msg(fail) %s ", msg));
+                        }
+                            
+                    }
+                    return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+                }
+                
+            });
+            pushConsumer.start();
+        } catch (MQClientException e) {
+            throw new RuntimeException(e);
+        }
+        Assertions.assertNotNull(producer, "Get Producer Failed");
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
+            producer.send(message);
+        }
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+
+        await().atMost(180, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return retryMsgs.size() == SEND_NUM && firstMsgs.size() == 0;
+            }
+        });
+        
+        producer.shutdown();
+        pushConsumer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Simulate pushconsumer consumption return null, expect that the original message was not received, and capture all messages after message retry")
+    public void testNullConsumption(){
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        Map<String, MessageExt> firstMsgs = new ConcurrentHashMap<>();
+        Map<String, MessageExt> retryMsgs = new ConcurrentHashMap<>();
+
+        DefaultMQPushConsumer pushConsumer;
+        try{
+            pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook, new AllocateMessageQueueAveragely());
+            pushConsumer.setInstanceName(RandomUtils.getStringByUUID());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe(topic, tag);
+            pushConsumer.setMessageModel(MessageModel.CLUSTERING);
+            pushConsumer.setMaxReconsumeTimes(2);
+            pushConsumer.setMessageListener(new MessageListenerConcurrently(){
+                @Override
+                public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
+                        ConsumeConcurrentlyContext context) {
+                    for (MessageExt msg : msgs) {
+                        if(msg.getReconsumeTimes() == 2){
+                            retryMsgs.putIfAbsent(msg.getMsgId(), msg);
+                            log.info("consume success: {}",msg);
+                        }else{
+                            // Simulate consuming operations
+                            log.info("{}","Simulate consuming operations return null");
+                            firstMsgs.putIfAbsent(msg.getMsgId(), msg);
+                            log.info(String.format("recv msg(null) %s ", msg));
+                            return null;
+                        }
+                            
+                    }
+                    return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+                }
+            });
+            pushConsumer.start();
+        } catch (MQClientException e) {
+            throw new RuntimeException(e);
+        }
+        Assertions.assertNotNull(producer, "Get Producer Failed");
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
+            producer.send(message);
+        }
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+
+        await().atMost(180, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return retryMsgs.size() == SEND_NUM && firstMsgs.size() == SEND_NUM;
+            }
+        });
+        
+        producer.shutdown();
+        pushConsumer.shutdown();
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("Simulate pushconsumer consumption timeout, expect message retry")
+    public void testTimeoutConsumption(){
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        Map<String, MessageExt> firstMsgs = new ConcurrentHashMap<>();
+        Map<String, MessageExt> retryMsgs = new ConcurrentHashMap<>();
+
+        DefaultMQPushConsumer pushConsumer;
+        try{
+            pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook, new AllocateMessageQueueAveragely());
+            pushConsumer.setInstanceName(RandomUtils.getStringByUUID());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe(topic, tag);
+            pushConsumer.setMessageModel(MessageModel.CLUSTERING);
+            pushConsumer.setMaxReconsumeTimes(3);
+            pushConsumer.setConsumeTimeout(60000);
+            pushConsumer.setMessageListener(new MessageListenerConcurrently(){
+                @Override
+                public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
+                        ConsumeConcurrentlyContext context) {
+                    try {
+                        for (MessageExt msg : msgs) {
+                            if(msg.getReconsumeTimes() == 0){
+                                // Simulate time-consuming operations
+                                log.info("{}","Simulate time-consuming operations");
+                                Thread.sleep(65000); // Assume that message processing takes 20 seconds
+                                log.info("{}","Simulate time-consuming operations end");
+                                firstMsgs.putIfAbsent(msg.getMsgId(), msg);
+                                log.info(String.format("recv msg(timeout) %s ", msg));
+                            }else{
+                                retryMsgs.putIfAbsent(msg.getMsgId(), msg);
+                                log.info("consume success: {}",msg);
+                            }
+                        }
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                        return ConsumeConcurrentlyStatus.RECONSUME_LATER;
+                    }
+                    return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+                } 
+            });
+            pushConsumer.start();
+        } catch (MQClientException e) {
+            throw new RuntimeException(e);
+        }
+        Assertions.assertNotNull(producer, "Get Producer Failed");
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
+            producer.send(message);
+        }
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+
+        TestUtils.waitForMinutes(5);
+        Assertions.assertTrue(retryMsgs.size() == SEND_NUM, "retry message size is not equal to send message size");
+        
+        producer.shutdown();
+        pushConsumer.shutdown();
+    }
+
+    @Test
+    @DisplayName("The normal message is sent, and after the PushConsumer retry, the retry message is expected to be consumed")
+    public void testNormalTopicPushConsumerRetry() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Map<String, MessageExt> firstMsgs = new ConcurrentHashMap<>();
+        Map<String, MessageExt> retryMsgs = new ConcurrentHashMap<>();
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        DefaultMQPushConsumer pushConsumer;
+        try{
+            pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook, new AllocateMessageQueueAveragely());
+            pushConsumer.setInstanceName(RandomUtils.getStringByUUID());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe(topic, tag);
+            pushConsumer.setMessageListener(new MessageListenerConcurrently(){
+                @Override
+                public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
+                        ConsumeConcurrentlyContext context) {
+                    for (int i = 0; i < msgs.size(); i++) {
+                        MessageExt messageExt = msgs.get(i);
+                        // String bodyContent = String.valueOf(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(messageExt.getBody())));
+                        if (messageExt.getReconsumeTimes() == 0) {
+                            log.info(String.format("first normal msg %s ", messageExt));
+                            firstMsgs.putIfAbsent(messageExt.getMsgId().toString(), messageExt);
+                            return ConsumeConcurrentlyStatus.RECONSUME_LATER;
+                        } else if (messageExt.getReconsumeTimes() > 0) {
+                            log.info(String.format("retry  normal msg %s ", messageExt));
+                            retryMsgs.putIfAbsent(messageExt.getMsgId().toString(),messageExt);
+                        }
+                    }
+                    return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+                }
+                
+            });
+            pushConsumer.start();
+        } catch (MQClientException e) {
+            throw new RuntimeException(e);
+        }
+        Assertions.assertNotNull(producer, "Get Producer Failed");
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
+            producer.send(message);
+        }
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        //All messages are consumed.
+        await().atMost(240, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return firstMsgs.size() == retryMsgs.size() && retryMsgs.size() == SEND_NUM;
+            }
+        });
+        for (MessageExt messageExt : producer.getEnqueueMessages().getAllData()) {
+            Assertions.assertTrue(firstMsgs.containsKey(messageExt.getMsgId().toString()) || retryMsgs.containsKey(messageExt.getMsgId().toString()));
+        }
+        producer.shutdown();
+        pushConsumer.shutdown();
+    }
+
+    @Test
+    @DisplayName("The send order message, after the PushConsumer retry, is expected to consume the retry message, and the message consumption order and send order")
+    public void testFiFoTopicPushConsumerRetry() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+        Assertions.assertNotNull(producer, "Get producer failed");
+        Vector<MessageExt> recvMessages = new Vector<>();
+
+        DefaultMQPushConsumer pushConsumer;
+        try{
+            pushConsumer = new DefaultMQPushConsumer(groupId, rpcHook, new AllocateMessageQueueAveragely());
+            pushConsumer.setInstanceName(RandomUtils.getStringByUUID());
+            pushConsumer.setNamesrvAddr(namesrvAddr);
+            pushConsumer.subscribe(topic, tag);
+            pushConsumer.setSuspendCurrentQueueTimeMillis(1000);
+            pushConsumer.setMessageListener(new MessageListenerOrderly() {
+
+                @Override
+                public ConsumeOrderlyStatus consumeMessage(List<MessageExt> msgs, ConsumeOrderlyContext context) {
+                    for (int i = 0; i < msgs.size(); i++) {
+                        MessageExt messageExt = msgs.get(i);
+                        if (messageExt.getReconsumeTimes() == 0) {
+                            log.info(String.format("first normal msg %s ", messageExt));
+                            return ConsumeOrderlyStatus.SUSPEND_CURRENT_QUEUE_A_MOMENT;
+                        } else if (messageExt.getReconsumeTimes() > 0) {
+                            log.info(String.format("retry  normal msg %s ", messageExt));
+                            recvMessages.add(messageExt);
+                        }
+                    }
+                    return ConsumeOrderlyStatus.SUCCESS;
+                }
+                
+            });
+            pushConsumer.start();
+        } catch (MQClientException e) {
+            throw new RuntimeException(e);
+        }
+        Assertions.assertNotNull(producer, "Get Producer Failed");
+        List<MessageQueue> messageQueues = producer.fetchPublishMessageQueues(topic);
+        List<MessageQueue> sendQueues = new ArrayList<>();
+        sendQueues.add(messageQueues.get(0));
+        producer.sendWithQueue(sendQueues,tag,SEND_NUM);
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        //All messages are consumed.
+        await().atMost(240, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return recvMessages.size() == SEND_NUM;
+            }
+        });
+        for (int i = 0; i < SEND_NUM; i++) {
+            Assertions.assertEquals(i, Integer.parseInt(String.valueOf(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(recvMessages.get(i).getBody())))), "recv message failed");
+        }
+    }
+}
+

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/server/batch/BatchProducerTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/server/batch/BatchProducerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.server.batch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.rocketmq.client.consumer.MessageSelector;
+import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
+import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.cluster.LoadBalancingTest;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.enums.TESTSET;
+import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.MessageFactory;
+import org.apache.rocketmq.factory.ProducerFactory;
+import org.apache.rocketmq.frame.BaseOperate;
+import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.TestUtils;
+import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag(TESTSET.BATCHPRODUCER)
+@Tag(TESTSET.SMOKE)
+public class BatchProducerTest extends BaseOperate {
+    private final Logger log = LoggerFactory.getLogger(BatchProducerTest.class);
+    private String tag;
+    private final static int SEND_NUM = 10;
+
+    @BeforeEach
+    public void setUp() {
+        tag = NameUtils.getRandomTagName();
+    }
+
+    @Test
+    @DisplayName("Send 10 messages in batch, expect pushconsumer to accept them all")
+    public void testBatchProducer(){
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        consumer.subscribeAndStart(topic, tag, new RMQNormalListener());
+
+        Assertions.assertNotNull(producer);
+        List<Message> messages = new ArrayList<>();
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
+            messages.add(message);
+        }
+        
+        try {
+            producer.getProducer().send(messages);
+        } catch (Exception e) {
+            Assertions.fail(e.getMessage());
+        }
+
+        TestUtils.waitForSeconds(5);
+
+        Assertions.assertEquals(SEND_NUM, consumer.getListener().getDequeueMessages().getDataSize());
+
+        producer.shutdown();
+        consumer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Send 10 messages to a queue in batch , expect pushconsumer to accept them all")
+    public void testBatchProducer_queue(){
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        consumer.subscribeAndStart(topic, tag, new RMQNormalListener());
+
+        Assertions.assertNotNull(producer);
+        List<Message> messages = new ArrayList<>();
+        for (int i = 0; i < SEND_NUM; i++) {
+            Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
+            messages.add(message);
+        }
+        
+        List<MessageQueue> msgQueues = producer.fetchPublishMessageQueues(topic);
+        try {
+            producer.getProducer().send(messages,msgQueues.get(0));
+        } catch (Exception e) {
+            Assertions.fail(e.getMessage());
+        }
+
+        TestUtils.waitForSeconds(5);
+
+        Assertions.assertEquals(SEND_NUM, consumer.getListener().getDequeueMessages().getDataSize());
+
+        producer.shutdown();
+        consumer.shutdown();
+    }
+
+}

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/server/batch/BatchProducerTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/server/batch/BatchProducerTest.java
@@ -46,7 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Tag(TESTSET.BATCHPRODUCER)
-@Tag(TESTSET.SMOKE)
 public class BatchProducerTest extends BaseOperate {
     private final Logger log = LoggerFactory.getLogger(BatchProducerTest.class);
     private String tag;
@@ -59,18 +58,14 @@ public class BatchProducerTest extends BaseOperate {
 
     @Test
     @DisplayName("Send 10 messages in batch, expect pushconsumer to accept them all")
-    public void testBatchProducer(){
+    public void testBatchProducer() {
         String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
         String topic = getTopic(methodName);
         String groupId = getGroupId(methodName);
         RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
-        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
-        RMQNormalConsumer consumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,
+                new AllocateMessageQueueAveragely());
         consumer.subscribeAndStart(topic, tag, new RMQNormalListener());
 
         Assertions.assertNotNull(producer);
@@ -79,7 +74,7 @@ public class BatchProducerTest extends BaseOperate {
             Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
             messages.add(message);
         }
-        
+
         try {
             producer.getProducer().send(messages);
         } catch (Exception e) {
@@ -96,18 +91,14 @@ public class BatchProducerTest extends BaseOperate {
 
     @Test
     @DisplayName("Send 10 messages to a queue in batch , expect pushconsumer to accept them all")
-    public void testBatchProducer_queue(){
+    public void testBatchProducer_queue() {
         String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
         String topic = getTopic(methodName);
         String groupId = getGroupId(methodName);
         RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
-        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook,1);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
-        RMQNormalConsumer consumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,new AllocateMessageQueueAveragely());
+        RMQNormalConsumer consumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook,
+                new AllocateMessageQueueAveragely());
         consumer.subscribeAndStart(topic, tag, new RMQNormalListener());
 
         Assertions.assertNotNull(producer);
@@ -116,10 +107,10 @@ public class BatchProducerTest extends BaseOperate {
             Message message = MessageFactory.buildNormalMessage(topic, tag, String.valueOf(i));
             messages.add(message);
         }
-        
+
         List<MessageQueue> msgQueues = producer.fetchPublishMessageQueues(topic);
         try {
-            producer.getProducer().send(messages,msgQueues.get(0));
+            producer.getProducer().send(messages, msgQueues.get(0));
         } catch (Exception e) {
             Assertions.fail(e.getMessage());
         }

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/server/delay/DelayMessageTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/server/delay/DelayMessageTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Tag(TESTSET.DELAY)
 public class DelayMessageTest extends BaseOperate {
     private final Logger logger = LoggerFactory.getLogger(DelayMessageTest.class);
-    //private RMQOrderConsumer consumer;
+    // private RMQOrderConsumer consumer;
     private String tag;
     private String topic;
     private String groupId;
@@ -75,10 +75,11 @@ public class DelayMessageTest extends BaseOperate {
         int delayLevel = 1;
         RMQNormalConsumer consumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         consumer.subscribeAndStart(topic, "*", new RMQNormalListener());
-        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr,rpcHook);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
         producer.sendDelay(topic, delayLevel, SEND_NUM);
-        VerifyUtils.verifyDelayMessage(producer.getEnqueueMessages(), consumer.getListener().getDequeueMessages(), delayLevel);
+        VerifyUtils.verifyDelayMessage(producer.getEnqueueMessages(), consumer.getListener().getDequeueMessages(),
+                delayLevel);
 
         producer.shutdown();
         consumer.shutdown();
@@ -90,10 +91,11 @@ public class DelayMessageTest extends BaseOperate {
         int delayLevel = 4;
         RMQNormalConsumer consumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         consumer.subscribeAndStart(topic, "*", new RMQNormalListener());
-        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr,rpcHook);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
         producer.sendDelay(topic, delayLevel, SEND_NUM);
-        VerifyUtils.verifyDelayMessage(producer.getEnqueueMessages(), consumer.getListener().getDequeueMessages(), delayLevel);
+        VerifyUtils.verifyDelayMessage(producer.getEnqueueMessages(), consumer.getListener().getDequeueMessages(),
+                delayLevel);
 
         producer.shutdown();
         consumer.shutdown();
@@ -104,7 +106,7 @@ public class DelayMessageTest extends BaseOperate {
     @DisplayName("Send one delay message and set the delay test negative delay level, expecting message building wrong")
     public void testNegativeDelayLevel() {
         int delayLevel = -1;
-        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr,rpcHook);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
         assertThrows(Exception.class, () -> {
             Message msg = new Message(topic, "*", RandomUtils.getStringByUUID().getBytes());
@@ -121,7 +123,7 @@ public class DelayMessageTest extends BaseOperate {
     @DisplayName("Send one delay message and set the delay test delay level=19, expecting message building wrong")
     public void testDelayLevelWith19() {
         int delayLevel = 19;
-        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr,rpcHook);
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr, rpcHook);
 
         assertThrows(Exception.class, () -> {
             Message msg = new Message(topic, "*", RandomUtils.getStringByUUID().getBytes());

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/server/delay/DelayMessageTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/server/delay/DelayMessageTest.java
@@ -17,23 +17,33 @@
 
 package org.apache.rocketmq.server.delay;
 
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
 import org.apache.rocketmq.client.rmq.RMQNormalProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.enums.TESTSET;
 import org.apache.rocketmq.factory.ConsumerFactory;
 import org.apache.rocketmq.factory.ProducerFactory;
 import org.apache.rocketmq.frame.BaseOperate;
 import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
+import org.apache.rocketmq.remoting.exception.RemotingException;
 import org.apache.rocketmq.utils.MQAdmin;
 import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.RandomUtils;
 import org.apache.rocketmq.utils.VerifyUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag(TESTSET.SMOKE)
 @Tag(TESTSET.DELAY)
@@ -87,5 +97,39 @@ public class DelayMessageTest extends BaseOperate {
 
         producer.shutdown();
         consumer.shutdown();
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("Send one delay message and set the delay test negative delay level, expecting message building wrong")
+    public void testNegativeDelayLevel() {
+        int delayLevel = -1;
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr,rpcHook);
+
+        assertThrows(Exception.class, () -> {
+            Message msg = new Message(topic, "*", RandomUtils.getStringByUUID().getBytes());
+            msg.setDelayTimeLevel(delayLevel);
+            SendResult sendResult = producer.getProducer().send(msg);
+            logger.info(sendResult.toString());
+        }, "Send messages with a negative delay level, Expected send() to throw exception, but it didn't");
+
+        producer.shutdown();
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("Send one delay message and set the delay test delay level=19, expecting message building wrong")
+    public void testDelayLevelWith19() {
+        int delayLevel = 19;
+        RMQNormalProducer producer = ProducerFactory.getRMQProducer(namesrvAddr,rpcHook);
+
+        assertThrows(Exception.class, () -> {
+            Message msg = new Message(topic, "*", RandomUtils.getStringByUUID().getBytes());
+            msg.setDelayTimeLevel(delayLevel);
+            SendResult sendResult = producer.getProducer().send(msg);
+            logger.info(sendResult.toString());
+        }, "Send messages with delay level=19, Expected send() to throw exception, but it didn't");
+
+        producer.shutdown();
     }
 }

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/server/transaction/TransactionMessageTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/server/transaction/TransactionMessageTest.java
@@ -17,18 +17,25 @@
 
 package org.apache.rocketmq.server.transaction;
 
+import org.apache.rocketmq.client.consumer.MessageSelector;
 import org.apache.rocketmq.client.producer.LocalTransactionState;
+import org.apache.rocketmq.client.producer.TransactionListener;
 import org.apache.rocketmq.client.rmq.RMQNormalConsumer;
 import org.apache.rocketmq.client.rmq.RMQTransactionProducer;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.enums.TESTSET;
 import org.apache.rocketmq.factory.ConsumerFactory;
+import org.apache.rocketmq.factory.MessageFactory;
 import org.apache.rocketmq.factory.ProducerFactory;
 import org.apache.rocketmq.frame.BaseOperate;
 import org.apache.rocketmq.listener.rmq.concurrent.RMQNormalListener;
 import org.apache.rocketmq.listener.rmq.concurrent.TransactionListenerImpl;
 import org.apache.rocketmq.utils.MQAdmin;
 import org.apache.rocketmq.utils.NameUtils;
+import org.apache.rocketmq.utils.TestUtils;
 import org.apache.rocketmq.utils.VerifyUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -36,12 +43,19 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 
 @Tag(TESTSET.TRANSACTION)
 @Tag(TESTSET.SMOKE)
@@ -77,11 +91,179 @@ public class TransactionMessageTest extends BaseOperate {
         });
 
         RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.COMMIT_MESSAGE), rpcHook);
-        producer.send(topic, tag, SEND_NUM);
+        producer.sendTrans(topic, tag, SEND_NUM);
 
         VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), consumer.getListener().getDequeueMessages());
         producer.shutdown();
         consumer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Send 10 transaction messages and rollback directly (Checker does commit), expecting that these 10 messages cannot be consumed by PushConsumer")
+    public void testTrans_SendRollback_PushConsume() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(tag), new RMQNormalListener());
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName("client-transaction-msg-check-thread");
+                return thread;
+            }
+        });
+
+        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.ROLLBACK_MESSAGE), rpcHook);
+        producer.sendTrans(topic, tag, SEND_NUM);
+        //Wait for the callback, expecting not to commit the already rolled back message
+        TestUtils.waitForSeconds(60);
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        Assertions.assertEquals(0, pushConsumer.getListener().getDequeueMessages().getDataSize());
+        producer.shutdown();
+        pushConsumer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Send 10 transaction messages and COMMIT the transaction by Checker (perform COMMIT), expecting the 10 messages to be consumed by PushConsumer")
+    public void testTrans_SendCheckerCommit_PushConsume() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(tag), new RMQNormalListener());
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName("client-transaction-msg-check-thread");
+                return thread;
+            }
+        });
+
+        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.UNKNOW), rpcHook);
+        producer.sendTrans(topic, tag, SEND_NUM);
+
+        //Wait for the callback to execute commit
+        TestUtils.waitForSeconds(60);
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
+        producer.shutdown();
+        pushConsumer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Send 10 transaction messages and roll back the transaction by Checker (performing ROLLBACK), expecting that the 10 messages will not be consumed by PushConsumer")
+    public void testTrans_CheckerRollback() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(tag), new RMQNormalListener());
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName("client-transaction-msg-check-thread");
+                return thread;
+            }
+        });
+
+        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListenerImpl(LocalTransactionState.ROLLBACK_MESSAGE, LocalTransactionState.UNKNOW), rpcHook);
+        producer.sendTrans(topic, tag, SEND_NUM);
+        //Wait for the rollback and execute rollback
+        TestUtils.waitForSeconds(60);
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        Assertions.assertEquals(0, pushConsumer.getListener().getDequeueMessages().getDataSize());
+        producer.shutdown();
+        pushConsumer.shutdown();
+    }
+
+    @Test
+    @DisplayName("Send 10 transactional messages and commit them by checking back (Checker commits for partial messages), and the expected committed messages can be consumed by PushConsumer")
+    public void testTrans_SendCheckerPartionCommit() {
+        String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+
+        String topic = getTopic(methodName);
+        String groupId = getGroupId(methodName);
+
+        RMQNormalConsumer pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
+        pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(tag), new RMQNormalListener());
+
+        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
+        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
+        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
+        pullConsumer.shutdown();
+
+        AtomicInteger commitMsgNum = new AtomicInteger(0);
+        AtomicInteger rollbackMsgNum = new AtomicInteger(0);
+
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName("client-transaction-msg-check-thread");
+                return thread;
+            }
+        });
+        
+        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListener() {
+
+            @Override
+            public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
+                return LocalTransactionState.UNKNOW;
+            }
+
+            @Override
+            public LocalTransactionState checkLocalTransaction(MessageExt msg) {
+                if (Integer.parseInt(String.valueOf(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(msg.getBody())))) % 2 == 0) {
+                    commitMsgNum.getAndIncrement();
+                    return LocalTransactionState.COMMIT_MESSAGE;
+                } else {
+                    rollbackMsgNum.getAndIncrement();
+                    return LocalTransactionState.ROLLBACK_MESSAGE;
+                }
+            }
+            
+        }, rpcHook);
+        producer.sendTrans(topic, tag, SEND_NUM);
+        Assertions.assertNotNull(producer);
+
+        await().atMost(90, SECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() {
+                return rollbackMsgNum.get() == commitMsgNum.get() && commitMsgNum.get() == SEND_NUM / 2;
+            }
+        });
+        //Wait for the rollback and execute commit/rollback
+        TestUtils.waitForSeconds(60);
+        Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
+        Assertions.assertEquals(5, pushConsumer.getListener().getDequeueMessages().getDataSize());
+        producer.shutdown();
+        pushConsumer.shutdown();
     }
 
 }

--- a/java/e2e-v4/src/test/java/org/apache/rocketmq/server/transaction/TransactionMessageTest.java
+++ b/java/e2e-v4/src/test/java/org/apache/rocketmq/server/transaction/TransactionMessageTest.java
@@ -81,16 +81,19 @@ public class TransactionMessageTest extends BaseOperate {
         RMQNormalConsumer consumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         consumer.subscribeAndStart(topic, tag, new RMQNormalListener());
 
-        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread thread = new Thread(r);
-                thread.setName("client-transaction-msg-check-thread");
-                return thread;
-            }
-        });
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        thread.setName("client-transaction-msg-check-thread");
+                        return thread;
+                    }
+                });
 
-        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.COMMIT_MESSAGE), rpcHook);
+        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService,
+                new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.COMMIT_MESSAGE),
+                rpcHook);
         producer.sendTrans(topic, tag, SEND_NUM);
 
         VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), consumer.getListener().getDequeueMessages());
@@ -108,23 +111,23 @@ public class TransactionMessageTest extends BaseOperate {
         RMQNormalConsumer pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(tag), new RMQNormalListener());
 
-        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        thread.setName("client-transaction-msg-check-thread");
+                        return thread;
+                    }
+                });
 
-        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread thread = new Thread(r);
-                thread.setName("client-transaction-msg-check-thread");
-                return thread;
-            }
-        });
-
-        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.ROLLBACK_MESSAGE), rpcHook);
+        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService,
+                new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE,
+                        LocalTransactionState.ROLLBACK_MESSAGE),
+                rpcHook);
         producer.sendTrans(topic, tag, SEND_NUM);
-        //Wait for the callback, expecting not to commit the already rolled back message
+        // Wait for the callback, expecting not to commit the already rolled back
+        // message
         TestUtils.waitForSeconds(60);
         Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
         Assertions.assertEquals(0, pushConsumer.getListener().getDequeueMessages().getDataSize());
@@ -143,24 +146,22 @@ public class TransactionMessageTest extends BaseOperate {
         RMQNormalConsumer pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(tag), new RMQNormalListener());
 
-        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        thread.setName("client-transaction-msg-check-thread");
+                        return thread;
+                    }
+                });
 
-        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread thread = new Thread(r);
-                thread.setName("client-transaction-msg-check-thread");
-                return thread;
-            }
-        });
-
-        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.UNKNOW), rpcHook);
+        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService,
+                new TransactionListenerImpl(LocalTransactionState.COMMIT_MESSAGE, LocalTransactionState.UNKNOW),
+                rpcHook);
         producer.sendTrans(topic, tag, SEND_NUM);
 
-        //Wait for the callback to execute commit
+        // Wait for the callback to execute commit
         TestUtils.waitForSeconds(60);
         Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
         VerifyUtils.verifyNormalMessage(producer.getEnqueueMessages(), pushConsumer.getListener().getDequeueMessages());
@@ -178,23 +179,21 @@ public class TransactionMessageTest extends BaseOperate {
         RMQNormalConsumer pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(tag), new RMQNormalListener());
 
-        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        thread.setName("client-transaction-msg-check-thread");
+                        return thread;
+                    }
+                });
 
-        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread thread = new Thread(r);
-                thread.setName("client-transaction-msg-check-thread");
-                return thread;
-            }
-        });
-
-        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListenerImpl(LocalTransactionState.ROLLBACK_MESSAGE, LocalTransactionState.UNKNOW), rpcHook);
+        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService,
+                new TransactionListenerImpl(LocalTransactionState.ROLLBACK_MESSAGE, LocalTransactionState.UNKNOW),
+                rpcHook);
         producer.sendTrans(topic, tag, SEND_NUM);
-        //Wait for the rollback and execute rollback
+        // Wait for the rollback and execute rollback
         TestUtils.waitForSeconds(60);
         Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
         Assertions.assertEquals(0, pushConsumer.getListener().getDequeueMessages().getDataSize());
@@ -213,42 +212,41 @@ public class TransactionMessageTest extends BaseOperate {
         RMQNormalConsumer pushConsumer = ConsumerFactory.getRMQNormalConsumer(namesrvAddr, groupId, rpcHook);
         pushConsumer.subscribeAndStart(topic, MessageSelector.byTag(tag), new RMQNormalListener());
 
-        RMQNormalConsumer pullConsumer = ConsumerFactory.getRMQLitePullConsumer(namesrvAddr, groupId, rpcHook);
-        pullConsumer.subscribeAndStartLitePull(topic,MessageSelector.byTag(tag));
-        VerifyUtils.tryReceiveOnce(pullConsumer.getLitePullConsumer());
-        pullConsumer.shutdown();
-
         AtomicInteger commitMsgNum = new AtomicInteger(0);
         AtomicInteger rollbackMsgNum = new AtomicInteger(0);
 
-        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread thread = new Thread(r);
-                thread.setName("client-transaction-msg-check-thread");
-                return thread;
-            }
-        });
-        
-        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService, new TransactionListener() {
+        ExecutorService executorService = new ThreadPoolExecutor(2, 5, 100, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<Runnable>(2000), new ThreadFactory() {
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread thread = new Thread(r);
+                        thread.setName("client-transaction-msg-check-thread");
+                        return thread;
+                    }
+                });
 
-            @Override
-            public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
-                return LocalTransactionState.UNKNOW;
-            }
+        RMQTransactionProducer producer = ProducerFactory.getTransProducer(namesrvAddr, executorService,
+                new TransactionListener() {
 
-            @Override
-            public LocalTransactionState checkLocalTransaction(MessageExt msg) {
-                if (Integer.parseInt(String.valueOf(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(msg.getBody())))) % 2 == 0) {
-                    commitMsgNum.getAndIncrement();
-                    return LocalTransactionState.COMMIT_MESSAGE;
-                } else {
-                    rollbackMsgNum.getAndIncrement();
-                    return LocalTransactionState.ROLLBACK_MESSAGE;
-                }
-            }
-            
-        }, rpcHook);
+                    @Override
+                    public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
+                        return LocalTransactionState.UNKNOW;
+                    }
+
+                    @Override
+                    public LocalTransactionState checkLocalTransaction(MessageExt msg) {
+                        if (Integer
+                                .parseInt(String.valueOf(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(msg.getBody()))))
+                                % 2 == 0) {
+                            commitMsgNum.getAndIncrement();
+                            return LocalTransactionState.COMMIT_MESSAGE;
+                        } else {
+                            rollbackMsgNum.getAndIncrement();
+                            return LocalTransactionState.ROLLBACK_MESSAGE;
+                        }
+                    }
+
+                }, rpcHook);
         producer.sendTrans(topic, tag, SEND_NUM);
         Assertions.assertNotNull(producer);
 
@@ -258,7 +256,7 @@ public class TransactionMessageTest extends BaseOperate {
                 return rollbackMsgNum.get() == commitMsgNum.get() && commitMsgNum.get() == SEND_NUM / 2;
             }
         });
-        //Wait for the rollback and execute commit/rollback
+        // Wait for the rollback and execute commit/rollback
         TestUtils.waitForSeconds(60);
         Assertions.assertEquals(SEND_NUM, producer.getEnqueueMessages().getDataSize(), "send message failed");
         Assertions.assertEquals(5, pushConsumer.getListener().getDequeueMessages().getDataSize());

--- a/java/e2e-v4/src/test/resources/logback-test.xml
+++ b/java/e2e-v4/src/test/resources/logback-test.xml
@@ -19,7 +19,7 @@
 <configuration debug="false" scan="true" scanPeriod="1 seconds">
 
     <contextName>logback</contextName>
-    <!-- 输出到控制台 -->
+    <!-- Output to console -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <!--<pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level [%logger{12}#%M:%L] - %msg%n</pattern>-->


### PR DESCRIPTION
## Brief changelog

Added the java4.x client cluster filter pull test content

## Verifying this change

Content:

 - [x] Test some Settings of 4.x client message, pushconsumer, pullconsumer and producer
 - [x] Test Clust, single producer, multiple pushconsumer reception
 - [x] Test the Tag and the Sql, and find the relevant information content through the tag
 - [x] Test the pullconsumer by using updating offset(message ACK and message NACK)